### PR TITLE
Make rutabaga compile standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+kumquat/server/target/
 third_party/mesa3d/src/util/rust/target
 third_party/mesa3d/src/virtio/protocols/target/
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
+third_party/mesa3d/src/util/rust/target
+third_party/mesa3d/src/virtio/protocols/target/
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1"
 thiserror = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 zerocopy = { version = "0.8.13", features = ["derive"] }
-mesa3d_util = { path = "../third_party/mesa3d/src/util/rust/", version = "0.1.71" }
+mesa3d_util = { path = "third_party/mesa3d/src/util/rust/", version = "0.1.71" }
 
 # To build latest Vulkano, change version to git = "https://github.com/vulkano-rs/vulkano.git"
 vulkano = { version = "0.33.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ vulkano = { version = "0.33.0", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"
-anyhow = { workspace = true }
+anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/kumquat/server/Cargo.toml
+++ b/kumquat/server/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 gfxstream = ["rutabaga_gfx/gfxstream"]
 
 [dependencies]
-mesa3d_util = { version = "0.1.71"}
-mesa3d_protocols = { version = "0.1.7"}
+mesa3d_util = { path = "../../third_party/mesa3d/src/util/rust/", version = "0.1.71" }
+mesa3d_protocols = { path = "../../third_party/mesa3d/src/virtio/protocols", version = "0.1.7" }
 rutabaga_gfx = { path = "../../", version = "0.1.61"}
 zerocopy = { version = "0.8.13", features = ["derive"] }
 log = "0.4"

--- a/third_party/mesa3d/src/util/rust/Cargo.toml
+++ b/third_party/mesa3d/src/util/rust/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mesa3d_util"
+version = "0.1.71"
+authors = ["Mesa3D authors"]
+edition = "2021"
+description = "Utility crate part of Mesa3D project"
+license = "MIT"
+
+[lib]
+name = "mesa3d_util"
+path = "lib.rs"
+
+[dependencies]
+cfg-if = "1.0.0"
+libc = "0.2.116"
+remain = "0.2"
+thiserror = "1.0.23"
+zerocopy = { version = "0.8.13", features = ["derive"] }
+log = "0.4"
+
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+rustix = { version = "1.0.7", features = ["event", "fs", "mm", "net", "param", "pipe", "use-libc", "use-libc-auxv", "libc_errno"] }

--- a/third_party/mesa3d/src/util/rust/bytestream/mod.rs
+++ b/third_party/mesa3d/src/util/rust/bytestream/mod.rs
@@ -1,0 +1,90 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::io::BufRead;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Read;
+use std::io::Result;
+use std::mem::size_of;
+
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+
+pub struct Reader<'slice> {
+    data: &'slice [u8],
+}
+
+impl<'slice> Reader<'slice> {
+    /// Construct a new Reader wrapper over `data`.
+    pub fn new(data: &[u8]) -> Reader {
+        Reader { data }
+    }
+
+    /// Reads and consumes an object from the buffer.
+    pub fn read_obj<T: FromBytes>(&mut self) -> Result<T> {
+        let obj = <T>::read_from_prefix(self.data.as_bytes())
+            .map_err(|_e| Error::from(ErrorKind::UnexpectedEof))?;
+        self.consume(size_of::<T>());
+        Ok(obj.0)
+    }
+
+    #[allow(dead_code)]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.data.read(buf)
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Reads an object from the buffer without consuming it.
+    pub fn peek_obj<T: FromBytes>(&self) -> Result<T> {
+        let obj = <T>::read_from_prefix(self.data.as_bytes())
+            .map_err(|_e| Error::from(ErrorKind::UnexpectedEof))?;
+        Ok(obj.0)
+    }
+
+    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        self.data.read_exact(buf)
+    }
+
+    /// Consumes `amt` bytes from the underlying buffer. If `amt` is larger than the
+    /// remaining data left in this `Reader`, then all remaining data will be consumed.
+    pub fn consume(&mut self, amt: usize) {
+        self.data.consume(amt);
+    }
+}
+
+pub struct Writer<'slice> {
+    data: &'slice mut [u8],
+    index: usize,
+}
+
+impl<'slice> Writer<'slice> {
+    pub fn new(data: &mut [u8]) -> Writer {
+        Writer { data, index: 0 }
+    }
+
+    /// Writes an object to the buffer.
+    pub fn write_obj<T: FromBytes + IntoBytes + Immutable>(&mut self, val: T) -> Result<()> {
+        self.write_all(val.as_bytes())
+    }
+
+    pub fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        let new_index = self.index + buf.len();
+
+        let Some(data) = self.data.get_mut(self.index..new_index) else {
+            return Err(Error::from(ErrorKind::UnexpectedEof));
+        };
+
+        data.copy_from_slice(buf);
+        self.index = new_index;
+        Ok(())
+    }
+
+    pub fn bytes_written(&self) -> usize {
+        self.index
+    }
+}

--- a/third_party/mesa3d/src/util/rust/defines.rs
+++ b/third_party/mesa3d/src/util/rust/defines.rs
@@ -1,0 +1,117 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::fmt;
+use std::time::Duration;
+
+use crate::error::MesaError;
+use crate::error::MesaResult;
+use crate::OwnedDescriptor;
+
+/// Mapped memory caching flags (see virtio_gpu spec)
+pub const MESA_MAP_CACHE_MASK: u32 = 0x0f;
+pub const MESA_MAP_CACHE_CACHED: u32 = 0x01;
+pub const MESA_MAP_CACHE_UNCACHED: u32 = 0x02;
+pub const MESA_MAP_CACHE_WC: u32 = 0x03;
+/// Access flags (not in virtio_gpu spec)
+pub const MESA_MAP_ACCESS_MASK: u32 = 0xf0;
+pub const MESA_MAP_ACCESS_READ: u32 = 0x10;
+pub const MESA_MAP_ACCESS_WRITE: u32 = 0x20;
+pub const MESA_MAP_ACCESS_RW: u32 = 0x30;
+
+/// Mesa handle types (memory and sync in same namespace)
+pub const MESA_HANDLE_TYPE_MEM_OPAQUE_FD: u32 = 0x0001;
+pub const MESA_HANDLE_TYPE_MEM_DMABUF: u32 = 0x0002;
+pub const MESA_HANDLE_TYPE_MEM_OPAQUE_WIN32: u32 = 0x0003;
+pub const MESA_HANDLE_TYPE_MEM_SHM: u32 = 0x0004;
+pub const MESA_HANDLE_TYPE_MEM_ZIRCON: u32 = 0x0005;
+
+pub const MESA_HANDLE_TYPE_SIGNAL_OPAQUE_FD: u32 = 0x0010;
+pub const MESA_HANDLE_TYPE_SIGNAL_SYNC_FD: u32 = 0x0020;
+pub const MESA_HANDLE_TYPE_SIGNAL_OPAQUE_WIN32: u32 = 0x0030;
+pub const MESA_HANDLE_TYPE_SIGNAL_ZIRCON: u32 = 0x0040;
+pub const MESA_HANDLE_TYPE_SIGNAL_EVENT_FD: u32 = 0x0050;
+
+/// Handle to OS-specific memory or synchronization objects.
+pub struct MesaHandle {
+    pub os_handle: OwnedDescriptor,
+    pub handle_type: u32,
+}
+
+impl MesaHandle {
+    /// Clones an existing Mesahandle, by using OS specific mechanisms.
+    pub fn try_clone(&self) -> MesaResult<MesaHandle> {
+        let clone = self
+            .os_handle
+            .try_clone()
+            .map_err(|_| MesaError::InvalidMesaHandle)?;
+        Ok(MesaHandle {
+            os_handle: clone,
+            handle_type: self.handle_type,
+        })
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct MesaMapping {
+    pub ptr: u64,
+    pub size: u64,
+}
+
+impl fmt::Debug for MesaHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handle debug").finish()
+    }
+}
+
+pub enum TubeType {
+    Stream,
+    Packet,
+}
+
+pub enum WaitTimeout {
+    Finite(Duration),
+    NoTimeout,
+}
+
+pub struct WaitEvent {
+    pub connection_id: u64,
+    pub hung_up: bool,
+    pub readable: bool,
+}
+
+#[allow(dead_code)]
+pub const WAIT_CONTEXT_MAX: usize = 16;
+
+pub enum DescriptorType {
+    Unknown,
+    Memory(u32),
+    WritePipe,
+}
+
+/// # Safety
+///
+/// Caller must ensure that MappedRegion's lifetime contains the lifetime of
+/// pointer returned.
+pub unsafe trait MappedRegion: Send + Sync {
+    /// Returns a pointer to the beginning of the memory region. Should only be
+    /// used for passing this region to ioctls for setting guest memory.
+    fn as_ptr(&self) -> *mut u8;
+
+    /// Returns the size of the memory region in bytes.
+    fn size(&self) -> usize;
+
+    /// Returns mesa mapping representation of the region
+    fn as_mesa_mapping(&self) -> MesaMapping;
+}
+
+#[macro_export]
+macro_rules! log_status {
+    ($result:expr) => {
+        match $result {
+            Ok(_) => (),
+            Err(e) => error!("Error recieved: {}", e),
+        }
+    };
+}

--- a/third_party/mesa3d/src/util/rust/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/descriptor.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+/// Trait for forfeiting ownership of the current raw descriptor, and returning the raw descriptor
+pub trait IntoRawDescriptor {
+    fn into_raw_descriptor(self) -> RawDescriptor;
+}
+
+/// Trait for returning the underlying raw descriptor, without giving up ownership of the
+/// descriptor.
+pub trait AsRawDescriptor {
+    /// Returns the underlying raw descriptor.
+    ///
+    /// Since the descriptor is still owned by the provider, callers should not assume that it will
+    /// remain open for longer than the immediate call of this method. In particular, it is a
+    /// dangerous practice to store the result of this method for future use: instead, it should be
+    /// used to e.g. obtain a raw descriptor that is immediately passed to a system call.
+    ///
+    /// If you need to use the descriptor for a longer time (and particularly if you cannot reliably
+    /// track the lifetime of the providing object), you should probably consider using
+    /// `OwnedDescriptor` (possibly along with `IntoRawDescriptor`) to get full ownership
+    /// over a descriptor pointing to the same resource.
+    fn as_raw_descriptor(&self) -> RawDescriptor;
+}
+
+pub trait FromRawDescriptor {
+    /// # Safety
+    /// Safe only if the caller ensures nothing has access to the descriptor after passing it to
+    /// `from_raw_descriptor`
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self;
+}
+
+impl IntoRawDescriptor for i64 {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self as RawDescriptor
+    }
+}
+
+pub trait AsBorrowedDescriptor {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor;
+}

--- a/third_party/mesa3d/src/util/rust/error.rs
+++ b/third_party/mesa3d/src/util/rust/error.rs
@@ -1,0 +1,77 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::NulError;
+use std::io::Error as IoError;
+use std::num::TryFromIntError;
+use std::str::Utf8Error;
+
+use remain::sorted;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use rustix::io::Errno as RustixError;
+use thiserror::Error;
+
+/// An error generated while using this crate.
+#[sorted]
+#[derive(Error, Debug)]
+pub enum MesaError {
+    /// An error with the MesaHandle
+    #[error("invalid Mesa handle")]
+    InvalidMesaHandle,
+    /// An input/output error occured.
+    #[error("an input/output error occur: {0}")]
+    IoError(IoError),
+    /// Nul crate error.
+    #[error("Nul Error occured {0}")]
+    NulError(NulError),
+    /// Rustix crate error.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[error("The errno is {0}")]
+    RustixError(RustixError),
+    /// An attempted integer conversion failed.
+    #[error("int conversion failed: {0}")]
+    TryFromIntError(TryFromIntError),
+    /// The command is unsupported.
+    #[error("the requested function is not implemented")]
+    Unsupported,
+    /// Utf8 error.
+    #[error("an utf8 error occured: {0}")]
+    Utf8Error(Utf8Error),
+    /// An error with a free form context, similar to anyhow
+    #[error("operation failed: {0}")]
+    WithContext(&'static str),
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl From<RustixError> for MesaError {
+    fn from(e: RustixError) -> MesaError {
+        MesaError::RustixError(e)
+    }
+}
+
+impl From<NulError> for MesaError {
+    fn from(e: NulError) -> MesaError {
+        MesaError::NulError(e)
+    }
+}
+
+impl From<IoError> for MesaError {
+    fn from(e: IoError) -> MesaError {
+        MesaError::IoError(e)
+    }
+}
+
+impl From<TryFromIntError> for MesaError {
+    fn from(e: TryFromIntError) -> MesaError {
+        MesaError::TryFromIntError(e)
+    }
+}
+
+impl From<Utf8Error> for MesaError {
+    fn from(e: Utf8Error) -> MesaError {
+        MesaError::Utf8Error(e)
+    }
+}
+
+/// The result of an operation in this crate.
+pub type MesaResult<T> = std::result::Result<T, MesaError>;

--- a/third_party/mesa3d/src/util/rust/lib.rs
+++ b/third_party/mesa3d/src/util/rust/lib.rs
@@ -1,0 +1,33 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+mod bytestream;
+mod defines;
+mod descriptor;
+mod error;
+mod memory_mapping;
+mod shm;
+mod sys;
+
+pub use bytestream::Reader;
+pub use bytestream::Writer;
+pub use defines::*;
+pub use descriptor::AsBorrowedDescriptor;
+pub use descriptor::AsRawDescriptor;
+pub use descriptor::FromRawDescriptor;
+pub use descriptor::IntoRawDescriptor;
+pub use error::MesaError;
+pub use error::MesaResult;
+pub use memory_mapping::MemoryMapping;
+pub use shm::round_up_to_page_size;
+pub use shm::SharedMemory;
+pub use sys::platform::descriptor::OwnedDescriptor;
+pub use sys::platform::descriptor::RawDescriptor;
+pub use sys::platform::descriptor::DEFAULT_RAW_DESCRIPTOR;
+pub use sys::platform::event::Event;
+pub use sys::platform::pipe::create_pipe;
+pub use sys::platform::pipe::ReadPipe;
+pub use sys::platform::pipe::WritePipe;
+pub use sys::platform::tube::Listener;
+pub use sys::platform::tube::Tube;
+pub use sys::platform::wait_context::WaitContext;

--- a/third_party/mesa3d/src/util/rust/memory_mapping.rs
+++ b/third_party/mesa3d/src/util/rust/memory_mapping.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::defines::MappedRegion;
+use crate::sys::platform::MemoryMapping as PlatformMapping;
+use crate::MesaMapping;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+
+pub struct MemoryMapping {
+    mapping: PlatformMapping,
+}
+
+impl MemoryMapping {
+    pub fn from_safe_descriptor(
+        descriptor: OwnedDescriptor,
+        size: usize,
+        map_info: u32,
+    ) -> MesaResult<MemoryMapping> {
+        let mapping = PlatformMapping::from_safe_descriptor(descriptor, size, map_info)?;
+        Ok(MemoryMapping { mapping })
+    }
+
+    pub fn from_offset(
+        descriptor: &OwnedDescriptor,
+        offset: usize,
+        size: usize,
+    ) -> MesaResult<MemoryMapping> {
+        let mapping = PlatformMapping::from_offset(descriptor, offset, size)?;
+        Ok(MemoryMapping { mapping })
+    }
+
+    pub fn as_mesa_mapping(&self) -> MesaMapping {
+        MesaMapping {
+            ptr: self.mapping.addr as u64,
+            size: self.mapping.size as u64,
+        }
+    }
+}
+
+// SAFETY: Safe since these functions just access the MemoryMapping structure.
+unsafe impl MappedRegion for MemoryMapping {
+    fn as_ptr(&self) -> *mut u8 {
+        self.mapping.addr as *mut u8
+    }
+
+    fn size(&self) -> usize {
+        self.mapping.size
+    }
+
+    fn as_mesa_mapping(&self) -> MesaMapping {
+        self.as_mesa_mapping()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/meson.build
+++ b/third_party/mesa3d/src/util/rust/meson.build
@@ -1,0 +1,65 @@
+# Copyright © 2024 Google
+# SPDX-License-Identifier: MIT
+
+dep_cfg_if = dependency('cfg-if',
+  version: '>= 1.0.0',
+  fallback: ['cfg-if-1-rs', 'dep_cfg_if'],
+  required: true,
+)
+
+dep_thiserror = dependency('thiserror',
+  version: '>= 2.0.11',
+  fallback: ['thiserror-2-rs', 'dep_thiserror'],
+  required: true,
+)
+
+dep_remain = dependency('remain',
+  version: '>= 0.2.12',
+  fallback: ['remain-0.2-rs', 'dep_remain'],
+  required: true,
+)
+
+dep_zerocopy = dependency('zerocopy',
+  version: '>= 0.8.13',
+  fallback: ['zerocopy-0.8-rs', 'dep_zerocopy'],
+  required: true,
+)
+
+dep_zerocopy_derive = dependency('zerocopy-derive',
+  version: '>= 0.8.13',
+  fallback: ['zerocopy-derive-0.8-rs', 'dep_zerocopy_derive'],
+  required: true,
+)
+
+dep_mesa3d_util = [dep_cfg_if, dep_thiserror, dep_remain, dep_zerocopy,
+                   dep_zerocopy_derive]
+
+if host_machine.system() == 'linux'
+  dep_rustix = dependency('rustix',
+    version: '>= 0.38.31',
+    fallback: ['rustix-1-rs', 'dep_rustix'],
+    required: true,
+  )
+
+  dep_bitflags = dependency('bitflags',
+    version: '>= 2.6.0',
+    fallback: ['bitflags-2-rs', 'dep_bitflags'],
+    required: true,
+  )
+
+  dep_errno = dependency('errno',
+    version: '>= 0.3.8',
+    fallback: ['errno-0.3-rs', 'dep_errno'],
+    required: true,
+  )
+  
+  dep_mesa3d_util += [dep_rustix, dep_bitflags, dep_errno]
+endif
+
+libmesa_rust_util = static_library(
+  'mesa3d_util',
+  'lib.rs',
+  gnu_symbol_visibility : 'hidden',
+  rust_abi : 'rust',
+  dependencies: dep_mesa3d_util,
+)

--- a/third_party/mesa3d/src/util/rust/shm.rs
+++ b/third_party/mesa3d/src/util/rust/shm.rs
@@ -1,0 +1,56 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::CString;
+
+use crate::sys::platform::page_size;
+use crate::sys::platform::SharedMemory as PlatformSharedMemory;
+use crate::AsRawDescriptor;
+use crate::FromRawDescriptor;
+use crate::IntoRawDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+pub struct SharedMemory(pub(crate) PlatformSharedMemory);
+impl SharedMemory {
+    /// Creates a new shared memory object of the given size.
+    ///
+    /// |name| is purely for debugging purposes. It does not need to be unique, and it does
+    /// not affect any non-debugging related properties of the constructed shared memory.
+    pub fn new<T: Into<Vec<u8>>>(debug_name: T, size: u64) -> MesaResult<SharedMemory> {
+        let debug_name = CString::new(debug_name)?;
+        PlatformSharedMemory::new(&debug_name, size).map(SharedMemory)
+    }
+
+    pub fn size(&self) -> u64 {
+        self.0.size()
+    }
+}
+
+impl AsRawDescriptor for SharedMemory {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.0.as_raw_descriptor()
+    }
+}
+
+impl IntoRawDescriptor for SharedMemory {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.0.into_raw_descriptor()
+    }
+}
+
+impl From<SharedMemory> for OwnedDescriptor {
+    fn from(sm: SharedMemory) -> OwnedDescriptor {
+        // SAFETY:
+        // Safe because we own the SharedMemory at this point.
+        unsafe { OwnedDescriptor::from_raw_descriptor(sm.into_raw_descriptor()) }
+    }
+}
+
+/// Uses the system's page size in bytes to round the given value up to the nearest page boundary.
+pub fn round_up_to_page_size(v: u64) -> MesaResult<u64> {
+    v.checked_next_multiple_of(page_size()? as _)
+        .ok_or(MesaError::WithContext("rounding up caused overflow"))
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
@@ -1,0 +1,119 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::fs::File;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::os::fd::AsFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::OwnedFd;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::io::IntoRawFd;
+use std::os::unix::io::RawFd;
+
+use rustix::fs::fcntl_getfl;
+use rustix::fs::seek;
+use rustix::fs::OFlags;
+use rustix::fs::SeekFrom;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::FromRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::DescriptorType;
+
+pub type RawDescriptor = RawFd;
+pub const DEFAULT_RAW_DESCRIPTOR: RawDescriptor = -1;
+
+#[derive(Debug)]
+pub struct OwnedDescriptor {
+    owned: OwnedFd,
+}
+
+impl OwnedDescriptor {
+    pub fn try_clone(&self) -> Result<OwnedDescriptor> {
+        let clone = self.owned.try_clone()?;
+        Ok(OwnedDescriptor { owned: clone })
+    }
+
+    pub fn determine_type(&self) -> Result<DescriptorType> {
+        match seek(&self.owned, SeekFrom::End(0)) {
+            Ok(seek_size) => {
+                let size: u32 = seek_size
+                    .try_into()
+                    .map_err(|_| Error::from(ErrorKind::Unsupported))?;
+                Ok(DescriptorType::Memory(size))
+            }
+            _ => {
+                let flags = fcntl_getfl(&self.owned)?;
+                match flags & OFlags::ACCMODE {
+                    OFlags::WRONLY => Ok(DescriptorType::WritePipe),
+                    _ => Err(Error::from(ErrorKind::Unsupported)),
+                }
+            }
+        }
+    }
+}
+
+impl AsRawDescriptor for OwnedDescriptor {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.owned.as_raw_fd()
+    }
+}
+
+impl FromRawDescriptor for OwnedDescriptor {
+    // SAFETY:
+    // It is caller's responsibility to ensure that the descriptor is valid and
+    // stays valid for the lifetime of Self
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self {
+        OwnedDescriptor {
+            owned: OwnedFd::from_raw_fd(descriptor),
+        }
+    }
+}
+
+impl IntoRawDescriptor for OwnedDescriptor {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.owned.into_raw_fd()
+    }
+}
+
+impl AsFd for OwnedDescriptor {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.owned.as_fd()
+    }
+}
+
+impl AsRawDescriptor for File {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.as_raw_fd()
+    }
+}
+
+impl FromRawDescriptor for File {
+    // SAFETY:
+    // It is caller's responsibility to ensure that the descriptor is valid and
+    // stays valid for the lifetime of Self
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self {
+        File::from_raw_fd(descriptor)
+    }
+}
+
+impl IntoRawDescriptor for File {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.into_raw_fd()
+    }
+}
+
+impl From<File> for OwnedDescriptor {
+    fn from(f: File) -> OwnedDescriptor {
+        OwnedDescriptor { owned: f.into() }
+    }
+}
+
+impl From<OwnedFd> for OwnedDescriptor {
+    fn from(o: OwnedFd) -> OwnedDescriptor {
+        OwnedDescriptor { owned: o }
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/event.rs
@@ -1,0 +1,72 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::os::fd::OwnedFd;
+
+use rustix::event::eventfd;
+use rustix::event::EventfdFlags;
+use rustix::io::read;
+use rustix::io::write;
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaHandle;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::MESA_HANDLE_TYPE_SIGNAL_EVENT_FD;
+
+pub struct Event {
+    descriptor: OwnedDescriptor,
+}
+
+impl Event {
+    pub fn new() -> MesaResult<Event> {
+        let owned: OwnedFd = eventfd(0, EventfdFlags::empty())?;
+        Ok(Event {
+            descriptor: owned.into(),
+        })
+    }
+
+    pub fn signal(&mut self) -> MesaResult<()> {
+        let _ = write(&self.descriptor, &1u64.to_ne_bytes())?;
+        Ok(())
+    }
+
+    pub fn wait(&self) -> MesaResult<()> {
+        read(&self.descriptor, &mut 1u64.to_ne_bytes())?;
+        Ok(())
+    }
+
+    pub fn try_clone(&self) -> MesaResult<Event> {
+        let clone = self.descriptor.try_clone()?;
+        Ok(Event { descriptor: clone })
+    }
+}
+
+impl TryFrom<MesaHandle> for Event {
+    type Error = MesaError;
+    fn try_from(handle: MesaHandle) -> Result<Self, Self::Error> {
+        if handle.handle_type != MESA_HANDLE_TYPE_SIGNAL_EVENT_FD {
+            return Err(MesaError::InvalidMesaHandle);
+        }
+
+        Ok(Event {
+            descriptor: handle.os_handle,
+        })
+    }
+}
+
+impl From<Event> for MesaHandle {
+    fn from(evt: Event) -> Self {
+        MesaHandle {
+            os_handle: evt.descriptor,
+            handle_type: MESA_HANDLE_TYPE_SIGNAL_EVENT_FD,
+        }
+    }
+}
+
+impl AsBorrowedDescriptor for Event {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        &self.descriptor
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/memory_mapping.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/memory_mapping.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::c_void;
+use std::os::fd::AsFd;
+use std::ptr::null_mut;
+
+use rustix::mm::mmap;
+use rustix::mm::munmap;
+use rustix::mm::MapFlags;
+use rustix::mm::ProtFlags;
+
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::MESA_MAP_ACCESS_MASK;
+use crate::MESA_MAP_ACCESS_READ;
+use crate::MESA_MAP_ACCESS_RW;
+use crate::MESA_MAP_ACCESS_WRITE;
+
+/// Wraps an anonymous shared memory mapping in the current process. Provides
+/// RAII semantics including munmap when no longer needed.
+#[derive(Debug)]
+pub struct MemoryMapping {
+    pub addr: *mut c_void,
+    pub size: usize,
+}
+
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Sync for MemoryMapping {}
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Send for MemoryMapping {}
+
+impl Drop for MemoryMapping {
+    fn drop(&mut self) {
+        // SAFETY:
+        // This is safe because we mmap the area at addr ourselves, and nobody
+        // else is holding a reference to it.
+        unsafe {
+            munmap(self.addr, self.size).unwrap();
+        }
+    }
+}
+
+impl MemoryMapping {
+    fn do_mmap(
+        descriptor: &OwnedDescriptor,
+        offset: usize,
+        size: usize,
+        map_info: u32,
+    ) -> MesaResult<MemoryMapping> {
+        let prot = match map_info & MESA_MAP_ACCESS_MASK {
+            MESA_MAP_ACCESS_READ => ProtFlags::READ,
+            MESA_MAP_ACCESS_WRITE => ProtFlags::WRITE,
+            MESA_MAP_ACCESS_RW => ProtFlags::READ | ProtFlags::WRITE,
+            _ => return Err(MesaError::WithContext("incorrect access flags")),
+        };
+
+        // SAFETY:
+        // The inputs to the mmap() system call have been verified, and
+        // the kernel is trusted to deliver a correct result.
+        let addr = unsafe {
+            mmap(
+                null_mut(),
+                size,
+                prot,
+                MapFlags::SHARED,
+                descriptor.as_fd(),
+                offset.try_into().unwrap(),
+            )?
+        };
+
+        Ok(MemoryMapping { addr, size })
+    }
+
+    pub fn from_safe_descriptor(
+        descriptor: OwnedDescriptor,
+        size: usize,
+        map_info: u32,
+    ) -> MesaResult<MemoryMapping> {
+        Self::do_mmap(&descriptor, 0, size, map_info)
+    }
+
+    pub fn from_offset(
+        descriptor: &OwnedDescriptor,
+        offset: usize,
+        size: usize,
+    ) -> MesaResult<MemoryMapping> {
+        Self::do_mmap(descriptor, offset, size, MESA_MAP_ACCESS_RW)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/mod.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod descriptor;
+pub mod event;
+pub mod memory_mapping;
+pub mod pipe;
+pub mod shm;
+pub mod tube;
+pub mod wait_context;
+
+pub use memory_mapping::MemoryMapping;
+pub use shm::page_size;
+pub use shm::SharedMemory;

--- a/third_party/mesa3d/src/util/rust/sys/linux/pipe.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/pipe.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::os::fd::AsFd;
+
+use rustix::io::read;
+use rustix::io::write;
+use rustix::pipe::pipe;
+
+use crate::AsBorrowedDescriptor;
+use crate::AsRawDescriptor;
+use crate::FromRawDescriptor;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+pub struct ReadPipe {
+    descriptor: OwnedDescriptor,
+}
+
+pub struct WritePipe {
+    descriptor: OwnedDescriptor,
+}
+
+pub fn create_pipe() -> MesaResult<(ReadPipe, WritePipe)> {
+    let (read_pipe, write_pipe) = pipe()?;
+    Ok((
+        ReadPipe {
+            descriptor: read_pipe.into(),
+        },
+        WritePipe {
+            descriptor: write_pipe.into(),
+        },
+    ))
+}
+
+impl ReadPipe {
+    pub fn read(&self, data: &mut [u8]) -> MesaResult<usize> {
+        let bytes_read = read(&self.descriptor, data)?;
+        Ok(bytes_read)
+    }
+}
+
+impl AsBorrowedDescriptor for ReadPipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        &self.descriptor
+    }
+}
+
+impl WritePipe {
+    pub fn new(descriptor: RawDescriptor) -> WritePipe {
+        // SAFETY: Safe because we know the underlying OS descriptor is valid and
+        // owned by us.
+        let owned = unsafe { OwnedDescriptor::from_raw_descriptor(descriptor) };
+        WritePipe { descriptor: owned }
+    }
+
+    pub fn write(&self, data: &[u8]) -> MesaResult<usize> {
+        let bytes_written = write(self.descriptor.as_fd(), data)?;
+        Ok(bytes_written)
+    }
+}
+
+impl AsBorrowedDescriptor for WritePipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        &self.descriptor
+    }
+}
+
+impl AsRawDescriptor for WritePipe {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.descriptor.as_raw_descriptor()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/shm.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/shm.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::CStr;
+use std::os::fd::AsRawFd;
+use std::os::fd::IntoRawFd;
+use std::os::unix::io::OwnedFd;
+
+use rustix::fs::ftruncate;
+use rustix::fs::memfd_create;
+use rustix::fs::MemfdFlags;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::MesaResult;
+use crate::RawDescriptor;
+
+pub struct SharedMemory {
+    fd: OwnedFd,
+    size: u64,
+}
+
+impl SharedMemory {
+    /// Creates a new shared memory file descriptor with zero size.
+    ///
+    /// If a name is given, it will appear in `/proc/self/fd/<shm fd>` for the purposes of
+    /// debugging. The name does not need to be unique.
+    ///
+    /// The file descriptor is opened with the close on exec flag and allows memfd sealing.
+    pub fn new(debug_name: &CStr, size: u64) -> MesaResult<SharedMemory> {
+        let fd = memfd_create(debug_name, MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING)?;
+
+        ftruncate(&fd, size)?;
+
+        Ok(SharedMemory { fd, size })
+    }
+
+    /// Gets the size in bytes of the shared memory.
+    ///
+    /// The size returned here does not reflect changes by other interfaces or users of the shared
+    /// memory file descriptor..
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+impl AsRawDescriptor for SharedMemory {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl IntoRawDescriptor for SharedMemory {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.fd.into_raw_fd()
+    }
+}
+
+pub fn page_size() -> MesaResult<u64> {
+    // TODO: Once all platforms support it, use rustix page_size() function everywhere.
+    Ok(rustix::param::page_size() as _)
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/tube.rs
@@ -1,0 +1,159 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::io::IoSlice;
+use std::io::IoSliceMut;
+use std::mem::MaybeUninit;
+use std::os::fd::AsFd;
+use std::path::Path;
+
+use rustix::cmsg_space;
+use rustix::fs::fcntl_setfl;
+use rustix::fs::OFlags;
+use rustix::net::accept;
+use rustix::net::bind;
+use rustix::net::connect;
+use rustix::net::listen;
+use rustix::net::recvmsg;
+use rustix::net::sendmsg;
+use rustix::net::socket_with;
+use rustix::net::AddressFamily;
+use rustix::net::RecvAncillaryBuffer;
+use rustix::net::RecvAncillaryMessage;
+use rustix::net::RecvFlags;
+use rustix::net::SendAncillaryBuffer;
+use rustix::net::SendAncillaryMessage;
+use rustix::net::SendFlags;
+use rustix::net::SocketAddrUnix;
+use rustix::net::SocketFlags;
+use rustix::net::SocketType;
+use rustix::path::Arg;
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::TubeType;
+
+const MAX_IDENTIFIERS: usize = 28;
+
+pub struct Tube {
+    socket: OwnedDescriptor,
+}
+
+impl Tube {
+    pub fn new<P: AsRef<Path> + Arg>(path: P, kind: TubeType) -> MesaResult<Tube> {
+        let socket = match kind {
+            TubeType::Packet => socket_with(
+                AddressFamily::UNIX,
+                SocketType::SEQPACKET,
+                SocketFlags::empty(),
+                None,
+            )?,
+            TubeType::Stream => socket_with(
+                AddressFamily::UNIX,
+                SocketType::STREAM,
+                SocketFlags::CLOEXEC,
+                None,
+            )?,
+        };
+
+        let unix_addr = SocketAddrUnix::new(path)?;
+        connect(&socket, &unix_addr)?;
+
+        Ok(Tube {
+            socket: socket.into(),
+        })
+    }
+
+    pub fn send(&self, opaque_data: &[u8], descriptors: &[OwnedDescriptor]) -> MesaResult<usize> {
+        let mut space = [MaybeUninit::<u8>::uninit(); cmsg_space!(ScmRights(MAX_IDENTIFIERS))];
+        let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);
+
+        let borrowed_fds: Vec<_> = descriptors.iter().map(AsFd::as_fd).collect();
+
+        let cmsg = SendAncillaryMessage::ScmRights(&borrowed_fds);
+        cmsg_buffer.push(cmsg);
+
+        let bytes_sent = sendmsg(
+            &self.socket,
+            &[IoSlice::new(opaque_data)],
+            &mut cmsg_buffer,
+            SendFlags::empty(),
+        )?;
+
+        Ok(bytes_sent)
+    }
+
+    pub fn receive(&self, opaque_data: &mut [u8]) -> MesaResult<(usize, Vec<OwnedDescriptor>)> {
+        let mut iovecs = [IoSliceMut::new(opaque_data)];
+
+        let mut space = [MaybeUninit::<u8>::uninit(); cmsg_space!(ScmRights(MAX_IDENTIFIERS))];
+        let mut cmsg_buffer = RecvAncillaryBuffer::new(&mut space);
+        let r = recvmsg(
+            &self.socket,
+            &mut iovecs,
+            &mut cmsg_buffer,
+            RecvFlags::empty(),
+        )?;
+
+        let len = r.bytes;
+        let mut received_descriptors: Vec<OwnedDescriptor> = Vec::new();
+
+        // Iterate over received control messages
+        for cmsg in cmsg_buffer.drain() {
+            match cmsg {
+                RecvAncillaryMessage::ScmRights(fds) => {
+                    received_descriptors.extend(fds.into_iter().map(Into::into));
+                }
+                _ => return Err(MesaError::Unsupported), // Handle unexpected control messages
+            }
+        }
+
+        Ok((len, received_descriptors))
+    }
+}
+
+impl AsBorrowedDescriptor for Tube {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        &self.socket
+    }
+}
+
+pub struct Listener {
+    socket: OwnedDescriptor,
+}
+
+impl Listener {
+    /// Creates a new `Listener` bound to the given path.
+    pub fn bind<P: AsRef<Path> + Arg>(path: P) -> MesaResult<Listener> {
+        let socket = socket_with(
+            AddressFamily::UNIX,
+            SocketType::SEQPACKET,
+            SocketFlags::empty(),
+            None,
+        )?;
+
+        let unix_addr = SocketAddrUnix::new(path)?;
+        bind(&socket, &unix_addr)?;
+        listen(&socket, 128)?;
+
+        fcntl_setfl(&socket, OFlags::NONBLOCK)?;
+
+        Ok(Listener {
+            socket: socket.into(),
+        })
+    }
+
+    pub fn accept(&self) -> MesaResult<Tube> {
+        let accepted_fd = accept(&self.socket)?;
+        let descriptor: OwnedDescriptor = accepted_fd.into();
+        Ok(Tube { socket: descriptor })
+    }
+}
+
+impl AsBorrowedDescriptor for Listener {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        &self.socket
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/linux/wait_context.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/wait_context.rs
@@ -1,0 +1,77 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::os::fd::OwnedFd;
+
+use rustix::event::epoll;
+use rustix::event::epoll::CreateFlags;
+use rustix::event::epoll::Event;
+use rustix::event::epoll::EventData;
+use rustix::event::epoll::EventFlags;
+use rustix::event::Timespec;
+use rustix::io::Errno;
+
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::WaitEvent;
+use crate::WaitTimeout;
+use crate::WAIT_CONTEXT_MAX;
+
+pub struct WaitContext {
+    epoll_ctx: OwnedFd,
+}
+
+impl WaitContext {
+    pub fn new() -> MesaResult<WaitContext> {
+        let epoll = epoll::create(CreateFlags::CLOEXEC)?;
+        Ok(WaitContext { epoll_ctx: epoll })
+    }
+
+    pub fn add(&mut self, connection_id: u64, descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        epoll::add(
+            &self.epoll_ctx,
+            descriptor,
+            EventData::new_u64(connection_id),
+            EventFlags::IN,
+        )?;
+        Ok(())
+    }
+
+    pub fn wait(&mut self, timeout: WaitTimeout) -> MesaResult<Vec<WaitEvent>> {
+        let mut events_buffer: [epoll::Event; WAIT_CONTEXT_MAX] = [Event {
+            flags: EventFlags::IN,
+            data: EventData::new_u64(0),
+        }; WAIT_CONTEXT_MAX];
+
+        let epoll_timeout: Option<Timespec> = match timeout {
+            WaitTimeout::Finite(duration) => Some(duration.try_into()?),
+            WaitTimeout::NoTimeout => None, // Indefinite wait
+        };
+
+        let num_events = loop {
+            match epoll::wait(&self.epoll_ctx, &mut events_buffer, epoll_timeout.as_ref()) {
+                Err(Errno::INTR) => (), // Continue loop on EINTR
+                result => break result?,
+            }
+        };
+
+        let events = events_buffer[..num_events]
+            .iter()
+            .map(|e| {
+                let flags: EventFlags = e.flags;
+                WaitEvent {
+                    connection_id: e.data.u64(),
+                    readable: flags.contains(EventFlags::IN),
+                    hung_up: flags.contains(EventFlags::HUP),
+                }
+            })
+            .collect();
+
+        Ok(events)
+    }
+
+    pub fn delete(&mut self, descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        epoll::delete(&self.epoll_ctx, descriptor)?;
+        Ok(())
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/mod.rs
+++ b/third_party/mesa3d/src/util/rust/sys/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub mod linux;
+
+#[cfg(any(target_os = "fuchsia", target_os = "macos", target_os = "nto"))]
+pub mod stub;
+
+#[cfg(windows)]
+pub mod windows;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(target_os = "android", target_os = "linux"))] {
+        pub use linux as platform;
+    } else if #[cfg(windows)] {
+        pub use windows as platform;
+    } else if #[cfg(any(target_os = "fuchsia", target_os = "macos", target_os = "nto"))] {
+        pub use stub as platform;
+    } else {
+        compile_error!("Unsupported platform");
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/descriptor.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::fs::File;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::os::fd::AsFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::OwnedFd;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::io::IntoRawFd;
+use std::os::unix::io::RawFd;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::FromRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::DescriptorType;
+
+pub type RawDescriptor = RawFd;
+pub const DEFAULT_RAW_DESCRIPTOR: RawDescriptor = -1;
+
+pub struct OwnedDescriptor {
+    owned: OwnedFd,
+}
+
+impl OwnedDescriptor {
+    pub fn try_clone(&self) -> Result<OwnedDescriptor> {
+        let clone = self.owned.try_clone()?;
+        Ok(OwnedDescriptor { owned: clone })
+    }
+
+    pub fn determine_type(&self) -> Result<DescriptorType> {
+        Err(Error::from(ErrorKind::Unsupported))
+    }
+}
+
+impl AsRawDescriptor for OwnedDescriptor {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.owned.as_raw_fd()
+    }
+}
+
+impl FromRawDescriptor for OwnedDescriptor {
+    // SAFETY:
+    // It is caller's responsibility to ensure that the descriptor is valid and
+    // stays valid for the lifetime of Self
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self {
+        OwnedDescriptor {
+            owned: OwnedFd::from_raw_fd(descriptor),
+        }
+    }
+}
+
+impl IntoRawDescriptor for OwnedDescriptor {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.owned.into_raw_fd()
+    }
+}
+
+impl AsFd for OwnedDescriptor {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.owned.as_fd()
+    }
+}
+
+impl AsRawDescriptor for File {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.as_raw_fd()
+    }
+}
+
+impl FromRawDescriptor for File {
+    // SAFETY:
+    // It is caller's responsibility to ensure that the descriptor is valid and
+    // stays valid for the lifetime of Self
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self {
+        File::from_raw_fd(descriptor)
+    }
+}
+
+impl IntoRawDescriptor for File {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.into_raw_fd()
+    }
+}
+
+impl From<File> for OwnedDescriptor {
+    fn from(f: File) -> OwnedDescriptor {
+        OwnedDescriptor { owned: f.into() }
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/event.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaHandle;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+
+pub struct Event;
+
+impl Event {
+    pub fn new() -> MesaResult<Event> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn signal(&mut self) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn wait(&self) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn try_clone(&self) -> MesaResult<Event> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl TryFrom<MesaHandle> for Event {
+    type Error = MesaError;
+    fn try_from(_handle: MesaHandle) -> Result<Self, Self::Error> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl From<Event> for MesaHandle {
+    fn from(_evt: Event) -> Self {
+        unimplemented!()
+    }
+}
+
+impl AsBorrowedDescriptor for Event {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/memory_mapping.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/memory_mapping.rs
@@ -1,0 +1,41 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use std::ffi::c_void;
+
+/// Wraps an anonymous shared memory mapping in the current process. Provides
+/// RAII semantics including munmap when no longer needed.
+#[derive(Debug)]
+pub struct MemoryMapping {
+    pub addr: *mut c_void,
+    pub size: usize,
+}
+
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Sync for MemoryMapping {}
+
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Send for MemoryMapping {}
+
+impl MemoryMapping {
+    pub fn from_safe_descriptor(
+        _descriptor: OwnedDescriptor,
+        _size: usize,
+        _map_info: u32,
+    ) -> MesaResult<MemoryMapping> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn from_offset(
+        _descriptor: &OwnedDescriptor,
+        _offset: usize,
+        _size: usize,
+    ) -> MesaResult<MemoryMapping> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/mod.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod descriptor;
+pub mod event;
+pub mod memory_mapping;
+pub mod pipe;
+pub mod shm;
+pub mod tube;
+pub mod wait_context;
+
+pub use memory_mapping::MemoryMapping;
+pub use shm::page_size;
+pub use shm::SharedMemory;

--- a/third_party/mesa3d/src/util/rust/sys/stub/pipe.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/pipe.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::AsBorrowedDescriptor;
+use crate::AsRawDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+pub struct ReadPipe;
+pub struct WritePipe;
+
+pub fn create_pipe() -> MesaResult<(ReadPipe, WritePipe)> {
+    Err(MesaError::Unsupported)
+}
+
+impl ReadPipe {
+    pub fn read(&self, _data: &mut [u8]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for ReadPipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl WritePipe {
+    pub fn new(_descriptor: RawDescriptor) -> WritePipe {
+        unimplemented!()
+    }
+
+    pub fn write(&self, _data: &[u8]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for WritePipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl AsRawDescriptor for WritePipe {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        unimplemented!()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/shm.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/shm.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::CStr;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::RawDescriptor;
+
+pub struct SharedMemory {
+    size: u64,
+}
+
+impl SharedMemory {
+    /// Creates a new shared memory file descriptor with zero size.
+    pub fn new(_debug_name: &CStr, _size: u64) -> MesaResult<SharedMemory> {
+        Err(MesaError::Unsupported)
+    }
+
+    /// Gets the size in bytes of the shared memory.
+    ///
+    /// The size returned here does not reflect changes by other interfaces or users of the shared
+    /// memory file descriptor..
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+impl AsRawDescriptor for SharedMemory {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        unimplemented!()
+    }
+}
+
+impl IntoRawDescriptor for SharedMemory {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        unimplemented!()
+    }
+}
+
+pub fn page_size() -> MesaResult<u64> {
+    Err(MesaError::Unsupported)
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/tube.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::path::Path;
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::TubeType;
+
+pub struct Tube;
+pub struct Listener;
+
+impl Tube {
+    pub fn new<P: AsRef<Path>>(_path: P, _kind: TubeType) -> MesaResult<Tube> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn send(&self, _opaque_data: &[u8], _descriptors: &[OwnedDescriptor]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn receive(&self, _opaque_data: &mut [u8]) -> MesaResult<(usize, Vec<OwnedDescriptor>)> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for Tube {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl Listener {
+    /// Creates a new `Listener` bound to the given path.
+    pub fn bind<P: AsRef<Path>>(_path: P) -> MesaResult<Listener> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn accept(&self) -> MesaResult<Tube> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/stub/wait_context.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/wait_context.rs
@@ -1,0 +1,28 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::WaitEvent;
+use crate::WaitTimeout;
+
+pub struct WaitContext;
+
+impl WaitContext {
+    pub fn new() -> MesaResult<WaitContext> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn add(&mut self, _connection_id: u64, _descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn wait(&mut self, _timeout: WaitTimeout) -> MesaResult<Vec<WaitEvent>> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn delete(&mut self, _descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/descriptor.rs
@@ -1,0 +1,70 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::fs::File;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::os::windows::io::IntoRawHandle;
+use std::os::windows::io::OwnedHandle;
+use std::os::windows::io::RawHandle;
+use std::os::windows::raw::HANDLE;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::FromRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::DescriptorType;
+
+pub type RawDescriptor = RawHandle;
+// Same as winapi::um::handleapi::INVALID_HANDLE_VALUE, but avoids compile issues.
+pub const DEFAULT_RAW_DESCRIPTOR: RawDescriptor = -1isize as HANDLE;
+
+pub struct OwnedDescriptor {
+    owned: OwnedHandle,
+}
+
+impl OwnedDescriptor {
+    pub fn try_clone(&self) -> Result<OwnedDescriptor> {
+        let clone = self.owned.try_clone()?;
+        Ok(OwnedDescriptor { owned: clone })
+    }
+
+    pub fn determine_type(&self) -> Result<DescriptorType> {
+        Err(Error::from(ErrorKind::Unsupported))
+    }
+}
+
+impl AsRawDescriptor for OwnedDescriptor {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.owned.as_raw_handle()
+    }
+}
+
+impl FromRawDescriptor for OwnedDescriptor {
+    // SAFETY: It is caller's responsibility to ensure that the descriptor is valid.
+    unsafe fn from_raw_descriptor(descriptor: RawDescriptor) -> Self {
+        OwnedDescriptor {
+            owned: OwnedHandle::from_raw_handle(descriptor),
+        }
+    }
+}
+
+impl IntoRawDescriptor for OwnedDescriptor {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.owned.into_raw_handle()
+    }
+}
+
+impl IntoRawDescriptor for File {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.into_raw_handle()
+    }
+}
+
+impl From<File> for OwnedDescriptor {
+    fn from(f: File) -> OwnedDescriptor {
+        OwnedDescriptor { owned: f.into() }
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/event.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaHandle;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+
+pub struct Event;
+
+impl Event {
+    pub fn new() -> MesaResult<Event> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn signal(&mut self) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn wait(&self) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn try_clone(&self) -> MesaResult<Event> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl TryFrom<MesaHandle> for Event {
+    type Error = MesaError;
+    fn try_from(_handle: MesaHandle) -> Result<Self, Self::Error> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl From<Event> for MesaHandle {
+    fn from(_evt: Event) -> Self {
+        unimplemented!()
+    }
+}
+
+impl AsBorrowedDescriptor for Event {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/memory_mapping.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/memory_mapping.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::c_void;
+
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+
+/// Wraps an anonymous shared memory mapping in the current process. Provides
+/// RAII semantics including munmap when no longer needed.
+#[derive(Debug)]
+pub struct MemoryMapping {
+    pub addr: *mut c_void,
+    pub size: usize,
+}
+
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Sync for MemoryMapping {}
+
+// SAFETY:
+// MemoryMapping user must ensure it is used by one thread at a time.
+unsafe impl Send for MemoryMapping {}
+
+impl MemoryMapping {
+    pub fn from_safe_descriptor(
+        _descriptor: OwnedDescriptor,
+        _size: usize,
+        _map_info: u32,
+    ) -> MesaResult<MemoryMapping> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn from_offset(
+        _descriptor: &OwnedDescriptor,
+        _offset: usize,
+        _size: usize,
+    ) -> MesaResult<MemoryMapping> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/mod.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod descriptor;
+pub mod event;
+pub mod memory_mapping;
+pub mod pipe;
+pub mod shm;
+pub mod tube;
+pub mod wait_context;
+
+pub use memory_mapping::MemoryMapping;
+pub use shm::page_size;
+pub use shm::SharedMemory;

--- a/third_party/mesa3d/src/util/rust/sys/windows/pipe.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/pipe.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::AsBorrowedDescriptor;
+use crate::AsRawDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+pub struct ReadPipe;
+pub struct WritePipe;
+
+pub fn create_pipe() -> MesaResult<(ReadPipe, WritePipe)> {
+    Err(MesaError::Unsupported)
+}
+
+impl ReadPipe {
+    pub fn read(&self, _data: &mut [u8]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for ReadPipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl WritePipe {
+    pub fn new(_descriptor: RawDescriptor) -> WritePipe {
+        unimplemented!()
+    }
+
+    pub fn write(&self, _data: &[u8]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for WritePipe {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl AsRawDescriptor for WritePipe {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        unimplemented!()
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/shm.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/shm.rs
@@ -1,0 +1,52 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::ffi::CStr;
+
+use crate::descriptor::AsRawDescriptor;
+use crate::descriptor::IntoRawDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::RawDescriptor;
+
+/// A shared memory file descriptor and its size.
+pub struct SharedMemory {
+    pub descriptor: OwnedDescriptor,
+    pub size: u64,
+}
+
+impl SharedMemory {
+    /// Creates a new shared memory file mapping with zero size.
+    pub fn new(_debug_name: &CStr, _size: u64) -> MesaResult<Self> {
+        Err(MesaError::Unsupported)
+    }
+
+    /// Gets the size in bytes of the shared memory.
+    ///
+    /// The size returned here does not reflect changes by other interfaces or users of the shared
+    /// memory file descriptor.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+/// USE THIS CAUTIOUSLY. The returned handle is not a file handle and cannot be
+/// used as if it were one. It is a handle to a the associated file mapping object
+/// and should only be used for memory-mapping the file view.
+impl AsRawDescriptor for SharedMemory {
+    fn as_raw_descriptor(&self) -> RawDescriptor {
+        self.descriptor.as_raw_descriptor()
+    }
+}
+
+impl IntoRawDescriptor for SharedMemory {
+    fn into_raw_descriptor(self) -> RawDescriptor {
+        self.descriptor.into_raw_descriptor()
+    }
+}
+
+pub fn page_size() -> MesaResult<u64> {
+    // TODO: rustix ideally should support this using GetSystemInfo(..)
+    Err(MesaError::Unsupported)
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/tube.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::path::Path;
+
+use crate::AsBorrowedDescriptor;
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::TubeType;
+
+pub struct Tube;
+pub struct Listener;
+
+impl Tube {
+    pub fn new<P: AsRef<Path>>(_path: P, _kind: TubeType) -> MesaResult<Tube> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn send(&self, _opaque_data: &[u8], _descriptors: &[OwnedDescriptor]) -> MesaResult<usize> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn receive(&self, _opaque_data: &mut [u8]) -> MesaResult<(usize, Vec<OwnedDescriptor>)> {
+        Err(MesaError::Unsupported)
+    }
+}
+
+impl AsBorrowedDescriptor for Tube {
+    fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        unimplemented!()
+    }
+}
+
+impl Listener {
+    /// Creates a new `Listener` bound to the given path.
+    pub fn bind<P: AsRef<Path>>(_path: P) -> MesaResult<Listener> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn accept(&self) -> MesaResult<Tube> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/util/rust/sys/windows/wait_context.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/wait_context.rs
@@ -1,0 +1,28 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use crate::MesaError;
+use crate::MesaResult;
+use crate::OwnedDescriptor;
+use crate::WaitEvent;
+use crate::WaitTimeout;
+
+pub struct WaitContext;
+
+impl WaitContext {
+    pub fn new() -> MesaResult<WaitContext> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn add(&mut self, _connection_id: u64, _descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn wait(&mut self, _timeout: WaitTimeout) -> MesaResult<Vec<WaitEvent>> {
+        Err(MesaError::Unsupported)
+    }
+
+    pub fn delete(&mut self, _descriptor: &OwnedDescriptor) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+}

--- a/third_party/mesa3d/src/virtio/protocols/Cargo.toml
+++ b/third_party/mesa3d/src/virtio/protocols/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mesa3d_protocols"
+version = "0.1.7"
+authors = ["Mesa3D authors"]
+edition = "2021"
+description = "Rust protocols from Mesa3D project"
+license = "MIT"
+
+[lib]
+name = "mesa3d_protocols"
+path = "lib.rs"
+
+[dependencies]
+mesa3d_util = {path = "../../util/rust", version = "0.1.71"}
+zerocopy = { version = "0.8.13", features = ["derive"] }
+
+[profile.dev]
+lto = true
+incremental = false
+
+[workspace]

--- a/third_party/mesa3d/src/virtio/protocols/ipc/kumquat_stream.rs
+++ b/third_party/mesa3d/src/virtio/protocols/ipc/kumquat_stream.rs
@@ -1,0 +1,223 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+use std::collections::VecDeque;
+use std::mem::size_of;
+
+use mesa3d_util::AsBorrowedDescriptor;
+use mesa3d_util::MesaError;
+use mesa3d_util::MesaHandle;
+use mesa3d_util::MesaResult;
+use mesa3d_util::OwnedDescriptor;
+use mesa3d_util::Reader;
+use mesa3d_util::Tube;
+use mesa3d_util::Writer;
+use mesa3d_util::MESA_HANDLE_TYPE_SIGNAL_EVENT_FD;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+
+use crate::protocols::kumquat_gpu_protocol::*;
+
+const MAX_COMMAND_SIZE: usize = 4096;
+
+pub struct KumquatStream {
+    stream: Tube,
+    write_buffer: [u8; MAX_COMMAND_SIZE],
+    read_buffer: [u8; MAX_COMMAND_SIZE],
+}
+
+impl KumquatStream {
+    pub fn new(stream: Tube) -> KumquatStream {
+        KumquatStream {
+            stream,
+            write_buffer: [0; MAX_COMMAND_SIZE],
+            read_buffer: [0; MAX_COMMAND_SIZE],
+        }
+    }
+
+    pub fn write<T: FromBytes + IntoBytes + Immutable>(
+        &mut self,
+        encode: KumquatGpuProtocolWrite<T>,
+    ) -> MesaResult<()> {
+        let mut writer = Writer::new(&mut self.write_buffer);
+
+        let array: &[OwnedDescriptor] = match encode {
+            KumquatGpuProtocolWrite::Cmd(cmd) => {
+                writer.write_obj(cmd)?;
+                &[]
+            }
+            KumquatGpuProtocolWrite::CmdWithHandle(cmd, handle) => {
+                writer.write_obj(cmd)?;
+                &[handle.os_handle]
+            }
+            KumquatGpuProtocolWrite::CmdWithData(cmd, data) => {
+                writer.write_obj(cmd)?;
+                writer.write_all(&data)?;
+                &[]
+            }
+        };
+
+        let bytes_written = writer.bytes_written();
+        self.stream
+            .send(&self.write_buffer[0..bytes_written], array)?;
+        Ok(())
+    }
+
+    pub fn read(&mut self) -> MesaResult<Vec<KumquatGpuProtocol>> {
+        let mut vec: Vec<KumquatGpuProtocol> = Vec::new();
+        let (bytes_read, descriptor_vec) = self.stream.receive(&mut self.read_buffer)?;
+        let mut descriptors: VecDeque<OwnedDescriptor> = descriptor_vec.into();
+
+        if bytes_read == 0 {
+            vec.push(KumquatGpuProtocol::OkNoData);
+            return Ok(vec);
+        }
+
+        let mut reader = Reader::new(&self.read_buffer[0..bytes_read]);
+        while reader.available_bytes() != 0 {
+            let hdr = reader.peek_obj::<kumquat_gpu_protocol_ctrl_hdr>()?;
+            let protocol = match hdr.type_ {
+                KUMQUAT_GPU_PROTOCOL_GET_NUM_CAPSETS => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::GetNumCapsets
+                }
+                KUMQUAT_GPU_PROTOCOL_GET_CAPSET_INFO => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::GetCapsetInfo(hdr.payload)
+                }
+                KUMQUAT_GPU_PROTOCOL_GET_CAPSET => {
+                    KumquatGpuProtocol::GetCapset(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_CTX_CREATE => {
+                    KumquatGpuProtocol::CtxCreate(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_CTX_DESTROY => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::CtxDestroy(hdr.payload)
+                }
+                KUMQUAT_GPU_PROTOCOL_CTX_ATTACH_RESOURCE => {
+                    KumquatGpuProtocol::CtxAttachResource(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_CTX_DETACH_RESOURCE => {
+                    KumquatGpuProtocol::CtxDetachResource(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESOURCE_CREATE_3D => {
+                    KumquatGpuProtocol::ResourceCreate3d(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_TRANSFER_TO_HOST_3D => {
+                    let os_handle = descriptors.pop_front().ok_or(MesaError::Unsupported)?;
+                    let resp: kumquat_gpu_protocol_transfer_host_3d = reader.read_obj()?;
+
+                    let handle = MesaHandle {
+                        os_handle,
+                        handle_type: MESA_HANDLE_TYPE_SIGNAL_EVENT_FD,
+                    };
+
+                    KumquatGpuProtocol::TransferToHost3d(resp, handle)
+                }
+                KUMQUAT_GPU_PROTOCOL_TRANSFER_FROM_HOST_3D => {
+                    let os_handle = descriptors.pop_front().ok_or(MesaError::Unsupported)?;
+                    let resp: kumquat_gpu_protocol_transfer_host_3d = reader.read_obj()?;
+
+                    let handle = MesaHandle {
+                        os_handle,
+                        handle_type: MESA_HANDLE_TYPE_SIGNAL_EVENT_FD,
+                    };
+
+                    KumquatGpuProtocol::TransferFromHost3d(resp, handle)
+                }
+                KUMQUAT_GPU_PROTOCOL_SUBMIT_3D => {
+                    let cmd: kumquat_gpu_protocol_cmd_submit = reader.read_obj()?;
+                    if reader.available_bytes() < cmd.size.try_into()? {
+                        // Large command buffers should handled via shared memory.
+                        return Err(MesaError::Unsupported);
+                    } else if reader.available_bytes() != 0 {
+                        let num_in_fences = cmd.num_in_fences as usize;
+                        let cmd_size = cmd.size as usize;
+                        let mut cmd_buf = vec![0; cmd_size];
+                        let mut fence_ids: Vec<u64> = Vec::with_capacity(num_in_fences);
+                        for _ in 0..num_in_fences {
+                            match reader.read_obj::<u64>() {
+                                Ok(fence_id) => {
+                                    fence_ids.push(fence_id);
+                                }
+                                Err(_) => return Err(MesaError::Unsupported),
+                            }
+                        }
+                        reader.read_exact(&mut cmd_buf[..])?;
+                        KumquatGpuProtocol::CmdSubmit3d(cmd, cmd_buf, fence_ids)
+                    } else {
+                        KumquatGpuProtocol::CmdSubmit3d(cmd, Vec::new(), Vec::new())
+                    }
+                }
+                KUMQUAT_GPU_PROTOCOL_RESOURCE_CREATE_BLOB => {
+                    KumquatGpuProtocol::ResourceCreateBlob(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_SNAPSHOT_SAVE => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::SnapshotSave
+                }
+                KUMQUAT_GPU_PROTOCOL_SNAPSHOT_RESTORE => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::SnapshotRestore
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_NUM_CAPSETS => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::RespNumCapsets(hdr.payload)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_CAPSET_INFO => {
+                    KumquatGpuProtocol::RespCapsetInfo(reader.read_obj()?)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_CAPSET => {
+                    let len: usize = hdr.payload.try_into()?;
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    let mut capset: Vec<u8> = vec![0; len];
+                    reader.read_exact(&mut capset)?;
+                    KumquatGpuProtocol::RespCapset(capset)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_CONTEXT_CREATE => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::RespContextCreate(hdr.payload)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_RESOURCE_CREATE => {
+                    let os_handle = descriptors.pop_front().ok_or(MesaError::Unsupported)?;
+                    let resp: kumquat_gpu_protocol_resp_resource_create = reader.read_obj()?;
+
+                    let handle = MesaHandle {
+                        os_handle,
+                        handle_type: resp.handle_type,
+                    };
+
+                    KumquatGpuProtocol::RespResourceCreate(resp, handle)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_CMD_SUBMIT_3D => {
+                    let os_handle = descriptors.pop_front().ok_or(MesaError::Unsupported)?;
+                    let resp: kumquat_gpu_protocol_resp_cmd_submit_3d = reader.read_obj()?;
+
+                    let handle = MesaHandle {
+                        os_handle,
+                        handle_type: resp.handle_type,
+                    };
+
+                    KumquatGpuProtocol::RespCmdSubmit3d(resp.fence_id, handle)
+                }
+                KUMQUAT_GPU_PROTOCOL_RESP_OK_SNAPSHOT => {
+                    reader.consume(size_of::<kumquat_gpu_protocol_ctrl_hdr>());
+                    KumquatGpuProtocol::RespOkSnapshot
+                }
+                _ => {
+                    return Err(MesaError::Unsupported);
+                }
+            };
+
+            vec.push(protocol);
+        }
+
+        Ok(vec)
+    }
+
+    pub fn as_borrowed_descriptor(&self) -> &OwnedDescriptor {
+        self.stream.as_borrowed_descriptor()
+    }
+}

--- a/third_party/mesa3d/src/virtio/protocols/ipc/mod.rs
+++ b/third_party/mesa3d/src/virtio/protocols/ipc/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod kumquat_stream;
+pub use kumquat_stream::KumquatStream;

--- a/third_party/mesa3d/src/virtio/protocols/lib.rs
+++ b/third_party/mesa3d/src/virtio/protocols/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod ipc;
+pub mod protocols;

--- a/third_party/mesa3d/src/virtio/protocols/meson.build
+++ b/third_party/mesa3d/src/virtio/protocols/meson.build
@@ -1,0 +1,11 @@
+# Copyright © 2024 Google
+# SPDX-License-Identifier: MIT
+
+libmesa_protocols = static_library(
+  'mesa3d_protocols',
+  'lib.rs',
+  gnu_symbol_visibility : 'hidden',
+  rust_abi : 'rust',
+  link_with: [libmesa_rust_util],
+  dependencies: dep_mesa3d_util
+)

--- a/third_party/mesa3d/src/virtio/protocols/protocols/kumquat_gpu_protocol.rs
+++ b/third_party/mesa3d/src/virtio/protocols/protocols/kumquat_gpu_protocol.rs
@@ -1,0 +1,270 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+//! Protocol based on ${crosvm_src}/devices/src/virtio/gpu/protocol.rs
+
+use mesa3d_util::MesaHandle;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+
+/// A unique identifier for a device.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    FromBytes,
+    IntoBytes,
+    Immutable,
+)]
+#[repr(C)]
+pub struct DeviceId {
+    pub device_uuid: [u8; 16],
+    pub driver_uuid: [u8; 16],
+}
+
+/// Memory index and physical device id of the associated VkDeviceMemory.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    FromBytes,
+    IntoBytes,
+    Immutable,
+)]
+#[repr(C)]
+pub struct VulkanInfo {
+    pub memory_idx: u32,
+    pub device_id: DeviceId,
+}
+
+/* 2d commands */
+pub const KUMQUAT_GPU_PROTOCOL_RESOURCE_UNREF: u32 = 0x100;
+pub const KUMQUAT_GPU_PROTOCOL_GET_NUM_CAPSETS: u32 = 0x101;
+pub const KUMQUAT_GPU_PROTOCOL_GET_CAPSET_INFO: u32 = 0x102;
+pub const KUMQUAT_GPU_PROTOCOL_GET_CAPSET: u32 = 0x103;
+pub const KUMQUAT_GPU_PROTOCOL_RESOURCE_CREATE_BLOB: u32 = 0x104;
+
+/* 3d commands */
+pub const KUMQUAT_GPU_PROTOCOL_CTX_CREATE: u32 = 0x200;
+pub const KUMQUAT_GPU_PROTOCOL_CTX_DESTROY: u32 = 0x201;
+pub const KUMQUAT_GPU_PROTOCOL_CTX_ATTACH_RESOURCE: u32 = 0x202;
+pub const KUMQUAT_GPU_PROTOCOL_CTX_DETACH_RESOURCE: u32 = 0x203;
+pub const KUMQUAT_GPU_PROTOCOL_RESOURCE_CREATE_3D: u32 = 0x204;
+pub const KUMQUAT_GPU_PROTOCOL_TRANSFER_TO_HOST_3D: u32 = 0x205;
+pub const KUMQUAT_GPU_PROTOCOL_TRANSFER_FROM_HOST_3D: u32 = 0x206;
+pub const KUMQUAT_GPU_PROTOCOL_SUBMIT_3D: u32 = 0x207;
+pub const KUMQUAT_GPU_PROTOCOL_RESOURCE_MAP_BLOB: u32 = 0x208;
+pub const KUMQUAT_GPU_PROTOCOL_RESOURCE_UNMAP_BLOB: u32 = 0x209;
+pub const KUMQUAT_GPU_PROTOCOL_SNAPSHOT_SAVE: u32 = 0x208;
+pub const KUMQUAT_GPU_PROTOCOL_SNAPSHOT_RESTORE: u32 = 0x209;
+
+/* success responses */
+pub const KUMQUAT_GPU_PROTOCOL_RESP_NODATA: u32 = 0x3001;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_NUM_CAPSETS: u32 = 0x3002;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_CAPSET_INFO: u32 = 0x3003;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_CAPSET: u32 = 0x3004;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_CONTEXT_CREATE: u32 = 0x3005;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_RESOURCE_CREATE: u32 = 0x3006;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_CMD_SUBMIT_3D: u32 = 0x3007;
+pub const KUMQUAT_GPU_PROTOCOL_RESP_OK_SNAPSHOT: u32 = 0x3008;
+
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_ctrl_hdr {
+    pub type_: u32,
+    pub payload: u32,
+}
+
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_box {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub w: u32,
+    pub h: u32,
+    pub d: u32,
+}
+
+/* KUMQUAT_GPU_PROTOCOL_TRANSFER_TO_HOST_3D, KUMQUAT_GPU_PROTOCOL_TRANSFER_FROM_HOST_3D */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_transfer_host_3d {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub box_: kumquat_gpu_protocol_box,
+    pub offset: u64,
+    pub level: u32,
+    pub stride: u32,
+    pub layer_stride: u32,
+    pub ctx_id: u32,
+    pub resource_id: u32,
+    pub padding: u32,
+}
+
+/* KUMQUAT_GPU_PROTOCOL_RESOURCE_CREATE_3D */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_resource_create_3d {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub target: u32,
+    pub format: u32,
+    pub bind: u32,
+    pub width: u32,
+    pub height: u32,
+    pub depth: u32,
+    pub array_size: u32,
+    pub last_level: u32,
+    pub nr_samples: u32,
+    pub flags: u32,
+    pub size: u32,
+    pub stride: u32,
+    pub ctx_id: u32,
+}
+
+#[derive(Clone, Debug, Copy, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_ctx_create {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub nlen: u32,
+    pub context_init: u32,
+    pub debug_name: [u8; 64],
+}
+
+impl Default for kumquat_gpu_protocol_ctx_create {
+    fn default() -> Self {
+        // SAFETY: All zero pattern is safe for this particular struct
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+
+/* KUMQUAT_GPU_PROTOCOL_CTX_ATTACH_RESOURCE, KUMQUAT_GPU_PROTOCOL_CTX_DETACH_RESOURCE */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_ctx_resource {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub ctx_id: u32,
+    pub resource_id: u32,
+}
+
+/* KUMQUAT_GPU_PROTOCOL_SUBMIT_3D */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_cmd_submit {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub ctx_id: u32,
+    pub pad: u32,
+    pub size: u32,
+
+    // The in-fence IDs are prepended to the cmd_buf and memory layout
+    // of the KUMQUAT_GPU_PROTOCOL_SUBMIT_3D buffer looks like this:
+    //   _________________
+    //   | CMD_SUBMIT_3D |
+    //   -----------------
+    //   |  header       |
+    //   |  in-fence IDs |
+    //   |  cmd_buf      |
+    //   -----------------
+    //
+    // This makes in-fence IDs naturally aligned to the sizeof(u64) inside
+    // of the virtio buffer.
+    pub num_in_fences: u32,
+    pub flags: u32,
+    pub ring_idx: u8,
+    pub padding: [u8; 3],
+}
+
+/* KUMQUAT_GPU_PROTOCOL_RESP_CAPSET_INFO */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_resp_capset_info {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub capset_id: u32,
+    pub version: u32,
+    pub size: u32,
+    pub padding: u32,
+}
+
+/* KUMQUAT_GPU_PROTOCOL_GET_CAPSET */
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_get_capset {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub capset_id: u32,
+    pub capset_version: u32,
+}
+
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_resource_create_blob {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub ctx_id: u32,
+    pub blob_mem: u32,
+    pub blob_flags: u32,
+    pub padding: u32,
+    pub blob_id: u64,
+    pub size: u64,
+}
+
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_resp_resource_create {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub resource_id: u32,
+    pub handle_type: u32,
+    pub vulkan_info: VulkanInfo,
+}
+
+#[derive(Copy, Clone, Debug, Default, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct kumquat_gpu_protocol_resp_cmd_submit_3d {
+    pub hdr: kumquat_gpu_protocol_ctrl_hdr,
+    pub fence_id: u64,
+    pub handle_type: u32,
+    pub padding: u32,
+}
+
+/// A virtio gpu command and associated metadata specific to each command.
+#[derive(Debug)]
+pub enum KumquatGpuProtocol {
+    OkNoData,
+    GetNumCapsets,
+    GetCapsetInfo(u32),
+    GetCapset(kumquat_gpu_protocol_get_capset),
+    CtxCreate(kumquat_gpu_protocol_ctx_create),
+    CtxDestroy(u32),
+    CtxAttachResource(kumquat_gpu_protocol_ctx_resource),
+    CtxDetachResource(kumquat_gpu_protocol_ctx_resource),
+    ResourceCreate3d(kumquat_gpu_protocol_resource_create_3d),
+    TransferToHost3d(kumquat_gpu_protocol_transfer_host_3d, MesaHandle),
+    TransferFromHost3d(kumquat_gpu_protocol_transfer_host_3d, MesaHandle),
+    CmdSubmit3d(kumquat_gpu_protocol_cmd_submit, Vec<u8>, Vec<u64>),
+    ResourceCreateBlob(kumquat_gpu_protocol_resource_create_blob),
+    SnapshotSave,
+    SnapshotRestore,
+    RespNumCapsets(u32),
+    RespCapsetInfo(kumquat_gpu_protocol_resp_capset_info),
+    RespCapset(Vec<u8>),
+    RespContextCreate(u32),
+    RespResourceCreate(kumquat_gpu_protocol_resp_resource_create, MesaHandle),
+    RespCmdSubmit3d(u64, MesaHandle),
+    RespOkSnapshot,
+}
+
+pub enum KumquatGpuProtocolWrite<T: IntoBytes + FromBytes + Immutable> {
+    Cmd(T),
+    CmdWithHandle(T, MesaHandle),
+    CmdWithData(T, Vec<u8>),
+}

--- a/third_party/mesa3d/src/virtio/protocols/protocols/mod.rs
+++ b/third_party/mesa3d/src/virtio/protocols/protocols/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2025 Google
+// SPDX-License-Identifier: MIT
+
+pub mod kumquat_gpu_protocol;


### PR DESCRIPTION
This is a set of fixes required to make rutabaga compile standalone.  This is mostly related to the mesa3d dependency, which are being vendored for now.