### PR TITLE
rutabaga_gfx: add Windows mingw CI/CD

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./.github/actions/install-deps
       - name: Checkout gfxstream
         run: git clone --depth 1 https://github.com/google/gfxstream
-      - name: build and install gfxStream
+      - name: build and install gfxstream
         run: |
           cd gfxstream
           meson setup build
@@ -34,6 +34,51 @@ jobs:
           cargo build --package rutabaga_gfx --package kumquat_virtio
           --package rutabaga_gfx_ffi --features=gfxstream
           --target=x86_64-unknown-linux-gnu
+
+  build-windows-x86_64-with-gfxstream:
+    name: build rutabaga with gfxstream (windows x86_64)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          path-type: inherit
+          install: |
+            git
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-python
+            mingw-w64-ucrt-x86_64-meson
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-headers-git
+            mingw-w64-ucrt-x86_64-pkg-config
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rust-src
+      - name: Add windows-gnu target
+        run: rustup target add x86_64-pc-windows-gnu
+      - name: Checkout gfxstream
+        run: git clone --depth 1 https://github.com/google/gfxstream
+      - name: build and install gfxstream
+        shell: msys2 {0}
+        run: |
+          cd gfxstream
+          meson setup build
+          ninja -C build
+          ninja -C build install
+      - name: Build Project
+        shell: msys2 {0}
+        env:
+          PKG_CONFIG_PATH: /ucrt64/lib/pkgconfig
+          PKG_CONFIG_ALLOW_CROSS: 1
+        run: >
+          cargo build --package rutabaga_gfx --package kumquat_virtio
+          --package rutabaga_gfx_ffi --features=gfxstream
+          --target=x86_64-pc-windows-gnu
 
   build-linux-x86_64-with-virgl:
     name: build rutabaga with virgl (Linux x86_64)


### PR DESCRIPTION
Use the GNU build of gfxstream and rutabaga.  MSVC and mingw shouldn't a difference: we're just using mingw since we want a "Linux" like flow.