### PR TITLE
rutabaga_gfx: rename minigbm feature to gbm feature

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -108,7 +108,7 @@ jobs:
           sudo ninja -C build install
       - name: Build Project
         run: >
-          cargo build --package rutabaga_gfx --features=virgl_renderer,minigbm
+          cargo build --package rutabaga_gfx --features=virgl_renderer,gbm
           --target=x86_64-unknown-linux-gnu
 
   build-linux-aarch64:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "BSD-3-Clause"
 gfxstream = []
 gfxstream_stub = []
 virgl_renderer = []
-minigbm = []
+gbm = []
 # Vulkano features are just a prototype and not integrated yet into the ChromeOS build system.
 vulkano = ["dep:vulkano"]
 x = []

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use pkg_config::Error;
 
 pub type PkgConfigResult<T> = std::result::Result<T, Error>;
 
-fn minigbm() -> PkgConfigResult<()> {
+fn gbm() -> PkgConfigResult<()> {
     pkg_config::probe_library("gbm")?;
     Ok(())
 }
@@ -93,8 +93,8 @@ fn main() -> PkgConfigResult<()> {
         use_fence_passing_option1 = false;
     }
 
-    if env::var("CARGO_FEATURE_MINIGBM").is_ok() {
-        minigbm()?;
+    if env::var("CARGO_FEATURE_GBM").is_ok() {
+        gbm()?;
     }
 
     if env::var("CARGO_FEATURE_GFXSTREAM").is_ok()

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -16,7 +16,6 @@ libc = "0.2.93"
 log = "0.4"
 
 [features]
-minigbm = ["rutabaga_gfx/minigbm"]
+gbm = ["rutabaga_gfx/gbm"]
 gfxstream = ["rutabaga_gfx/gfxstream"]
-virgl_renderer = ["rutabaga_gfx/virgl_renderer"]
 vulkano = ["rutabaga_gfx/vulkano"]

--- a/src/rutabaga_gralloc/gralloc.rs
+++ b/src/rutabaga_gralloc/gralloc.rs
@@ -15,7 +15,7 @@ use mesa3d_util::MesaError;
 use mesa3d_util::MesaHandle;
 
 use crate::rutabaga_gralloc::formats::*;
-#[cfg(feature = "minigbm")]
+#[cfg(feature = "gbm")]
 use crate::rutabaga_gralloc::minigbm::MinigbmDevice;
 use crate::rutabaga_gralloc::system_gralloc::SystemGralloc;
 #[cfg(feature = "vulkano")]
@@ -268,7 +268,7 @@ impl RutabagaGralloc {
             grallocs.insert(GrallocBackend::System, system);
         }
 
-        #[cfg(feature = "minigbm")]
+        #[cfg(feature = "gbm")]
         if flags.uses_gbm() {
             // crosvm integration tests build with the "wl-dmabuf" feature, which translates in
             // rutabaga to the "minigbm" feature.  These tests run on hosts where a rendernode is
@@ -328,7 +328,7 @@ impl RutabagaGralloc {
         #[allow(clippy::let_and_return)]
         let mut _backend = GrallocBackend::System;
 
-        #[cfg(feature = "minigbm")]
+        #[cfg(feature = "gbm")]
         {
             // See note on "wl-dmabuf" and Kokoro in Gralloc::new().
             if self.grallocs.contains_key(&GrallocBackend::Minigbm) {

--- a/src/rutabaga_gralloc/minigbm.rs
+++ b/src/rutabaga_gralloc/minigbm.rs
@@ -6,7 +6,7 @@
 //!
 //! External code found at <https://chromium.googlesource.com/chromiumos/platform/minigbm>.
 
-#![cfg(feature = "minigbm")]
+#![cfg(feature = "gbm")]
 
 use std::fs::File;
 use std::io::Error;

--- a/src/rutabaga_gralloc/minigbm_bindings.rs
+++ b/src/rutabaga_gralloc/minigbm_bindings.rs
@@ -5,7 +5,7 @@
 // Generated with bindgen --default-enum-style=rust --allowlist-function='gbm_.*'
 // --allowlist-type='gbm_.*' minigbm/gbm.h Then modified manually
 
-#![cfg(feature = "minigbm")]
+#![cfg(feature = "gbm")]
 /* Added below line manually */
 #![allow(dead_code, non_camel_case_types)]
 


### PR DESCRIPTION
Although the backend code is still named minigbm, we want to support gbm too.  There are some use cases that can benefit from it.

As first step in the migration, rename the feature flag to reflect the goals.