### PR TITLE
ffi: unbreak rutabaga_command ABI without unstable API

### DIFF
--- a/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/ffi/src/include/rutabaga_gfx_ffi.h
@@ -198,6 +198,9 @@ struct rutabaga_command {
 #ifdef RUTABAGA_GFX_FFI_UNSTABLE
     uint32_t num_in_fences;
     uint64_t *fence_ids;
+#else
+    uint32_t _reserved_1;
+    uint64_t *_reserved_2;
 #endif
 };
 


### PR DESCRIPTION
The num_in_fences/fence_ids fields always exist on the Rust side, so the size of the struct includes the new fields. They must always be present, so let's reserve them in the #else. Otherwise callers like qemu would allocate a smaller struct than the Rust side expects and pass uninitialized memory instead of zeroes, causing a from_raw_parts UB assertion to trip.

Bug=[b:440386997](https://issuetracker.google.com/440386997)