### PR TITLE
rutabaga_gfx: Make clippy happy for only virgl_renderer enabled

### DIFF
--- a/src/renderer_utils.rs
+++ b/src/renderer_utils.rs
@@ -33,5 +33,6 @@ pub struct RutabagaCookie {
     #[allow(dead_code)]
     pub render_server_fd: Option<OwnedDescriptor>,
     pub fence_handler: Option<RutabagaFenceHandler>,
+    #[allow(dead_code)]
     pub debug_handler: Option<RutabagaDebugHandler>,
 }

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -53,6 +53,7 @@ use crate::rutabaga_utils::RUTABAGA_CAPSET_VENUS;
 use crate::rutabaga_utils::RUTABAGA_CAPSET_VIRGL;
 use crate::rutabaga_utils::RUTABAGA_CAPSET_VIRGL2;
 use crate::rutabaga_utils::RUTABAGA_CONTEXT_INIT_CAPSET_ID_MASK;
+#[cfg(fence_passing_option1)]
 use crate::rutabaga_utils::RUTABAGA_FLAG_FENCE_HOST_SHAREABLE;
 use crate::rutabaga_utils::RUTABAGA_FLAG_INFO_RING_IDX;
 use crate::snapshot::RutabagaSnapshotReader;
@@ -1520,7 +1521,7 @@ mod tests {
     #[test]
     fn snapshot_restore_2d_no_resources() {
         let mut snapshot_dir = std::env::temp_dir();
-        snapshot_dir.push(format!("rutabaga_snapshot"));
+        snapshot_dir.push("rutabaga_snapshot");
 
         fs::create_dir(&snapshot_dir).unwrap();
 
@@ -1536,7 +1537,7 @@ mod tests {
     #[test]
     fn snapshot_restore_2d_one_resource() {
         let mut snapshot_dir = std::env::temp_dir();
-        snapshot_dir.push(format!("rutabaga_snapshot2"));
+        snapshot_dir.push("rutabaga_snapshot2");
         fs::create_dir(&snapshot_dir).unwrap();
 
         let resource_id = 123;

--- a/src/virgl_renderer.rs
+++ b/src/virgl_renderer.rs
@@ -12,7 +12,6 @@ use std::io::Error as SysError;
 use std::io::IoSlice;
 use std::io::IoSliceMut;
 use std::mem::size_of;
-use std::mem::transmute;
 use std::mem::ManuallyDrop;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
@@ -390,7 +389,8 @@ impl VirglRenderer {
             virgl_renderer_init(
                 cookie as *mut c_void,
                 virglrenderer_flags.into(),
-                transmute(VIRGL_RENDERER_CALLBACKS),
+                VIRGL_RENDERER_CALLBACKS as *const virgl_renderer_callbacks
+                    as *mut virgl_renderer_callbacks,
             )
         };
 


### PR DESCRIPTION
This fixes clippy warnings with the 1.81 Rust toolchain when only the
virgl_renderer feature is enabled.