### PR TITLE
Export VirtioFsKey and VirtioFsTable Publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub use crate::rutabaga_core::calculate_capset_mask;
 pub use crate::rutabaga_core::calculate_capset_names;
 pub use crate::rutabaga_core::Rutabaga;
 pub use crate::rutabaga_core::RutabagaBuilder;
+pub use crate::rutabaga_core::VirtioFsKey;
+pub use crate::rutabaga_core::VirtioFsTable;
 pub use crate::rutabaga_gralloc::DrmFormat;
 pub use crate::rutabaga_gralloc::ImageAllocationInfo;
 pub use crate::rutabaga_gralloc::ImageMemoryRequirements;

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -65,7 +65,7 @@ use crate::virgl_renderer::VirglRenderer;
 use crate::RutabagaPaths;
 
 /// Key for identifying a file in the VirtioFS table.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VirtioFsKey {
     /// VirtioFS filesystem ID (identifies which virtio-fs instance)
     pub fs_id: u64,


### PR DESCRIPTION
Add pub use statements for VirtioFsKey and VirtioFsTable in lib.rs. This allows libkrun to use these types when setting export_table.