### PR TITLE
gfxstream: wire external blob and native surface APIs

### DIFF
--- a/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/ffi/src/include/rutabaga_gfx_ffi.h
@@ -97,6 +97,7 @@ extern "C" {
  * Rutabaga WSI
  */
 #define RUTABAGA_WSI_SURFACELESS 0x1
+#define RUTABAGA_WSI_VULKAN_SWAPCHAIN 0x2
 
 /**
  * Rutabaga flags for creating fences.
@@ -376,6 +377,26 @@ int32_t rutabaga_resource_map_info(struct rutabaga *ptr, uint32_t resource_id, u
 int32_t rutabaga_submit_command(struct rutabaga *ptr, struct rutabaga_command *cmd);
 
 int32_t rutabaga_create_fence(struct rutabaga *ptr, const struct rutabaga_fence *fence);
+
+int32_t rutabaga_setup_native_surface(struct rutabaga *ptr, uint32_t display_id,
+                                       void *native_window_handle,
+                                       int32_t width_pt, int32_t height_pt,
+                                       int32_t width_px, int32_t height_px,
+                                       float dpr);
+
+int32_t rutabaga_teardown_native_surface(struct rutabaga *ptr, uint32_t display_id);
+
+int32_t rutabaga_resize_native_surface(struct rutabaga *ptr, uint32_t display_id,
+                                        int32_t width_pt, int32_t height_pt,
+                                        int32_t width_px, int32_t height_px,
+                                        float dpr);
+
+int32_t rutabaga_set_scanout_resource(struct rutabaga *ptr, uint32_t scanout_id,
+                                       uint32_t resource_id, uint32_t width, uint32_t height);
+
+int32_t rutabaga_present_flushed_resource(struct rutabaga *ptr, uint32_t resource_id,
+                                           uint32_t x, uint32_t y,
+                                           uint32_t width, uint32_t height);
 
 #ifdef RUTABAGA_GFX_FFI_UNSTABLE
 

--- a/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/ffi/src/include/rutabaga_gfx_ffi.h
@@ -391,6 +391,8 @@ int32_t rutabaga_resize_native_surface(struct rutabaga *ptr, uint32_t display_id
                                         int32_t width_px, int32_t height_px,
                                         float dpr);
 
+int32_t rutabaga_set_vsync_hz(struct rutabaga *ptr, uint32_t vsync_hz);
+
 int32_t rutabaga_set_scanout_resource(struct rutabaga *ptr, uint32_t scanout_id,
                                        uint32_t resource_id, uint32_t width, uint32_t height);
 

--- a/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/ffi/src/include/rutabaga_gfx_ffi.h
@@ -257,6 +257,16 @@ struct rutabaga_builder {
 
     // Optional, renderer specific, null-terminated C-string.
     const char *renderer_features;
+
+    // Optional, opaque gfxstream hooks forwarded into stream_renderer_init().
+    const void *gfxstream_vm_ops;
+    const void *address_space_hw_funcs;
+
+    // Optional gfxstream display geometry. When unset, rutabaga defaults apply.
+    uint32_t display_width;
+    uint32_t display_height;
+    uint32_t display_width_mm;
+    uint32_t display_height_mm;
 };
 
 /**
@@ -399,6 +409,36 @@ int32_t rutabaga_set_scanout_resource(struct rutabaga *ptr, uint32_t scanout_id,
 int32_t rutabaga_present_flushed_resource(struct rutabaga *ptr, uint32_t resource_id,
                                            uint32_t x, uint32_t y,
                                            uint32_t width, uint32_t height);
+
+/**
+ * Returns the active opaque gfxstream address-space control ops table.
+ * Returns null when gfxstream is unavailable.
+ */
+const void *rutabaga_gfxstream_get_address_space_device_control_ops(void);
+
+/**
+ * Overrides the opaque gfxstream address-space HW funcs table.
+ * Returns the previous pointer, or null if gfxstream is unavailable.
+ */
+const void *rutabaga_gfxstream_set_address_space_hw_funcs(const void *address_space_hw_funcs);
+
+/**
+ * Returns the active opaque goldfish-pipe service ops table.
+ * Returns null when gfxstream is unavailable or no ops have been installed.
+ */
+const void *rutabaga_gfxstream_get_service_ops(void);
+
+/**
+ * Overrides the opaque goldfish-pipe service ops table.
+ * Returns the previous pointer, or null if gfxstream is unavailable.
+ */
+const void *rutabaga_gfxstream_set_service_ops(const void *service_ops);
+
+/**
+ * Installs hardware-side callbacks (wake/close) for goldfish-pipe.
+ * Returns the previous pointer, or null if gfxstream is unavailable.
+ */
+const void *rutabaga_gfxstream_set_service_hw_funcs(const void *hw_funcs);
 
 #ifdef RUTABAGA_GFX_FFI_UNSTABLE
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -61,6 +61,7 @@ pub struct iovec {
 
 const NO_ERROR: i32 = 0;
 const RUTABAGA_WSI_SURFACELESS: u64 = 1;
+const RUTABAGA_WSI_VULKAN_SWAPCHAIN: u64 = 2;
 
 static S_DEBUG_HANDLER: OnceLock<Mutex<RutabagaDebugHandler>> = OnceLock::new();
 
@@ -262,6 +263,7 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
 
         let rutabaga_wsi = match builder.wsi {
             RUTABAGA_WSI_SURFACELESS => RutabagaWsi::Surfaceless,
+            RUTABAGA_WSI_VULKAN_SWAPCHAIN => RutabagaWsi::VulkanSwapchain,
             _ => return -EINVAL,
         };
 
@@ -734,6 +736,93 @@ pub unsafe extern "C" fn rutabaga_restore(ptr: &mut rutabaga, dir: *const c_char
 
         let result = ptr.restore(Path::new(directory));
         return_result(result)
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rutabaga_setup_native_surface(
+    ptr: &mut rutabaga,
+    display_id: u32,
+    native_window_handle: *mut c_void,
+    width_pt: i32,
+    height_pt: i32,
+    width_px: i32,
+    height_px: i32,
+    dpr: f32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        let result = ptr.setup_native_surface(
+            display_id, native_window_handle,
+            width_pt, height_pt, width_px, height_px, dpr);
+        return_result(result)
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_teardown_native_surface(
+    ptr: &mut rutabaga,
+    display_id: u32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        let result = ptr.teardown_native_surface(display_id);
+        return_result(result)
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rutabaga_resize_native_surface(
+    ptr: &mut rutabaga,
+    display_id: u32,
+    width_pt: i32,
+    height_pt: i32,
+    width_px: i32,
+    height_px: i32,
+    dpr: f32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        let result = ptr.resize_native_surface(
+            display_id, width_pt, height_pt, width_px, height_px, dpr);
+        return_result(result)
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_set_scanout_resource(
+    ptr: &mut rutabaga,
+    scanout_id: u32,
+    resource_id: u32,
+    width: u32,
+    height: u32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        let result = ptr.set_scanout_resource(scanout_id, resource_id, width, height);
+        return_result(result)
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_present_flushed_resource(
+    ptr: &mut rutabaga,
+    resource_id: u32,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        let result = ptr.present_flushed_resource(resource_id, x, y, width, height);
+        match result {
+            Ok(presented) => if presented { 1 } else { 0 },
+            Err(e) => {
+                log_error(e.to_string());
+                -EINVAL
+            }
+        }
     }))
     .unwrap_or(-ESRCH)
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -68,10 +68,47 @@ const NO_ERROR: i32 = 0;
 const RUTABAGA_WSI_SURFACELESS: u64 = 1;
 const RUTABAGA_WSI_VULKAN_SWAPCHAIN: u64 = 2;
 
-static S_DEBUG_HANDLER: OnceLock<Mutex<RutabagaDebugHandler>> = OnceLock::new();
+static S_DEBUG_HANDLER: OnceLock<Mutex<Option<RutabagaDebugHandler>>> = OnceLock::new();
+
+fn debug_handler_slot() -> &'static Mutex<Option<RutabagaDebugHandler>> {
+    S_DEBUG_HANDLER.get_or_init(|| Mutex::new(None))
+}
+
+struct ScopedDebugHandler {
+    previous_handler: Option<RutabagaDebugHandler>,
+    restore_on_drop: bool,
+}
+
+impl ScopedDebugHandler {
+    fn install(debug_handler_opt: Option<RutabagaDebugHandler>) -> ScopedDebugHandler {
+        let mut handler_slot = debug_handler_slot().lock().unwrap();
+        let previous_handler = std::mem::replace(&mut *handler_slot, debug_handler_opt);
+        ScopedDebugHandler {
+            previous_handler,
+            restore_on_drop: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.restore_on_drop = false;
+    }
+}
+
+impl Drop for ScopedDebugHandler {
+    fn drop(&mut self) {
+        if self.restore_on_drop {
+            *debug_handler_slot().lock().unwrap() = self.previous_handler.take();
+        }
+    }
+}
 
 fn log_error(debug_string: String) {
     if let Some(handler_mutex) = S_DEBUG_HANDLER.get() {
+        let handler_opt = handler_mutex.lock().unwrap().clone();
+        let Some(handler) = handler_opt else {
+            return;
+        };
+
         let cstring = CString::new(debug_string.as_str()).expect("CString creation failed");
 
         let debug = RutabagaDebug {
@@ -79,7 +116,6 @@ fn log_error(debug_string: String) {
             message: cstring.as_ptr(),
         };
 
-        let handler = handler_mutex.lock().unwrap();
         handler.call(debug);
     }
 }
@@ -233,13 +269,10 @@ pub unsafe extern "C" fn rutabaga_calculate_capset_mask(
 pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mut rutabaga) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
         let fence_handler = create_ffi_fence_handler(builder.user_data, builder.fence_cb);
-        let mut debug_handler_opt: Option<RutabagaDebugHandler> = None;
-
-        if let Some(func) = builder.debug_cb {
-            let debug_handler = create_ffi_debug_handler(builder.user_data, func);
-            let _ = S_DEBUG_HANDLER.set(Mutex::new(debug_handler.clone()));
-            debug_handler_opt = Some(debug_handler);
-        }
+        let debug_handler_opt = builder
+            .debug_cb
+            .map(|func| create_ffi_debug_handler(builder.user_data, func));
+        let mut debug_handler_scope = ScopedDebugHandler::install(debug_handler_opt.clone());
 
         let mut rutabaga_paths_opt = None;
         if let Some(paths) = builder.channels {
@@ -325,6 +358,7 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
         let result = rutabaga_builder.build();
 
         let rtbg = return_on_error!(result);
+        debug_handler_scope.disarm();
         *ptr = Box::into_raw(Box::new(rtbg)) as _;
         NO_ERROR
     }))
@@ -338,6 +372,7 @@ pub extern "C" fn rutabaga_finish(ptr: &mut *mut rutabaga) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
         let _ = unsafe { Box::from_raw(*ptr) };
         *ptr = null_mut();
+        *debug_handler_slot().lock().unwrap() = None;
         NO_ERROR
     }))
     .unwrap_or(-ESRCH)
@@ -752,8 +787,10 @@ pub extern "C" fn rutabaga_create_fence(ptr: &mut rutabaga, fence: &rutabaga_fen
 
 #[no_mangle]
 pub extern "C" fn rutabaga_gfxstream_get_address_space_device_control_ops() -> *const c_void {
-    catch_unwind(AssertUnwindSafe(|| gfxstream_get_address_space_device_control_ops()))
-        .unwrap_or(std::ptr::null())
+    catch_unwind(AssertUnwindSafe(|| {
+        gfxstream_get_address_space_device_control_ops()
+    }))
+    .unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]
@@ -768,18 +805,13 @@ pub extern "C" fn rutabaga_gfxstream_set_address_space_hw_funcs(
 
 #[no_mangle]
 pub extern "C" fn rutabaga_gfxstream_get_service_ops() -> *const c_void {
-    catch_unwind(AssertUnwindSafe(|| gfxstream_get_service_ops()))
-        .unwrap_or(std::ptr::null())
+    catch_unwind(AssertUnwindSafe(|| gfxstream_get_service_ops())).unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]
-pub extern "C" fn rutabaga_gfxstream_set_service_ops(
-    service_ops: *const c_void,
-) -> *const c_void {
-    catch_unwind(AssertUnwindSafe(|| {
-        gfxstream_set_service_ops(service_ops)
-    }))
-    .unwrap_or(std::ptr::null())
+pub extern "C" fn rutabaga_gfxstream_set_service_ops(service_ops: *const c_void) -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| gfxstream_set_service_ops(service_ops)))
+        .unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]
@@ -837,18 +869,21 @@ pub unsafe extern "C" fn rutabaga_setup_native_surface(
 ) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
         let result = ptr.setup_native_surface(
-            display_id, native_window_handle,
-            width_pt, height_pt, width_px, height_px, dpr);
+            display_id,
+            native_window_handle,
+            width_pt,
+            height_pt,
+            width_px,
+            height_px,
+            dpr,
+        );
         return_result(result)
     }))
     .unwrap_or(-ESRCH)
 }
 
 #[no_mangle]
-pub extern "C" fn rutabaga_teardown_native_surface(
-    ptr: &mut rutabaga,
-    display_id: u32,
-) -> i32 {
+pub extern "C" fn rutabaga_teardown_native_surface(ptr: &mut rutabaga, display_id: u32) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
         let result = ptr.teardown_native_surface(display_id);
         return_result(result)
@@ -867,18 +902,15 @@ pub unsafe extern "C" fn rutabaga_resize_native_surface(
     dpr: f32,
 ) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
-        let result = ptr.resize_native_surface(
-            display_id, width_pt, height_pt, width_px, height_px, dpr);
+        let result =
+            ptr.resize_native_surface(display_id, width_pt, height_pt, width_px, height_px, dpr);
         return_result(result)
     }))
     .unwrap_or(-ESRCH)
 }
 
 #[no_mangle]
-pub extern "C" fn rutabaga_set_vsync_hz(
-    ptr: &mut rutabaga,
-    vsync_hz: u32,
-) -> i32 {
+pub extern "C" fn rutabaga_set_vsync_hz(ptr: &mut rutabaga, vsync_hz: u32) -> i32 {
     catch_unwind(AssertUnwindSafe(|| {
         ptr.set_vsync_hz(vsync_hz);
         NO_ERROR
@@ -913,7 +945,13 @@ pub extern "C" fn rutabaga_present_flushed_resource(
     catch_unwind(AssertUnwindSafe(|| {
         let result = ptr.present_flushed_resource(resource_id, x, y, width, height);
         match result {
-            Ok(presented) => if presented { 1 } else { 0 },
+            Ok(presented) => {
+                if presented {
+                    1
+                } else {
+                    0
+                }
+            }
             Err(e) => {
                 log_error(e.to_string());
                 -EINVAL

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
 
         let result = RutabagaBuilder::new(builder.capset_mask, fence_handler)
             .set_default_component(component)
-            .set_use_external_blob(false)
+            .set_use_external_blob(true)
             .set_use_egl(true)
             .set_wsi(rutabaga_wsi)
             .set_debug_handler(debug_handler_opt)

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -29,6 +29,11 @@ use std::sync::OnceLock;
 use libc::iovec;
 use libc::EINVAL;
 use libc::ESRCH;
+use rutabaga_gfx::gfxstream_get_address_space_device_control_ops;
+use rutabaga_gfx::gfxstream_get_service_ops;
+use rutabaga_gfx::gfxstream_set_address_space_hw_funcs;
+use rutabaga_gfx::gfxstream_set_service_hw_funcs;
+use rutabaga_gfx::gfxstream_set_service_ops;
 use rutabaga_gfx::ResourceCreate3D;
 use rutabaga_gfx::ResourceCreateBlob;
 use rutabaga_gfx::Rutabaga;
@@ -177,6 +182,12 @@ pub struct rutabaga_builder<'a> {
     pub debug_cb: Option<rutabaga_debug_callback>,
     pub channels: Option<&'a rutabaga_channels>,
     pub renderer_features: *const c_char,
+    pub gfxstream_vm_ops: *const c_void,
+    pub address_space_hw_funcs: *const c_void,
+    pub display_width: u32,
+    pub display_height: u32,
+    pub display_width_mm: u32,
+    pub display_height_mm: u32,
 }
 
 fn create_ffi_fence_handler(
@@ -261,6 +272,18 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
             renderer_features_opt = Some(string);
         }
 
+        let gfxstream_vm_ops = if builder.gfxstream_vm_ops.is_null() {
+            None
+        } else {
+            Some(builder.gfxstream_vm_ops)
+        };
+
+        let address_space_hw_funcs = if builder.address_space_hw_funcs.is_null() {
+            None
+        } else {
+            Some(builder.address_space_hw_funcs)
+        };
+
         let rutabaga_wsi = match builder.wsi {
             RUTABAGA_WSI_SURFACELESS => RutabagaWsi::Surfaceless,
             RUTABAGA_WSI_VULKAN_SWAPCHAIN => RutabagaWsi::VulkanSwapchain,
@@ -272,7 +295,7 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
             component = RutabagaComponentType::Rutabaga2D;
         }
 
-        let result = RutabagaBuilder::new(builder.capset_mask, fence_handler)
+        let mut rutabaga_builder = RutabagaBuilder::new(builder.capset_mask, fence_handler)
             .set_default_component(component)
             .set_use_external_blob(true)
             .set_use_egl(true)
@@ -280,7 +303,26 @@ pub unsafe extern "C" fn rutabaga_init(builder: &rutabaga_builder, ptr: &mut *mu
             .set_debug_handler(debug_handler_opt)
             .set_rutabaga_paths(rutabaga_paths_opt)
             .set_renderer_features(renderer_features_opt)
-            .build();
+            .set_gfxstream_vm_ops(gfxstream_vm_ops)
+            .set_gfxstream_address_space_hw_funcs(address_space_hw_funcs);
+
+        if builder.display_width > 0 {
+            rutabaga_builder = rutabaga_builder.set_display_width(builder.display_width);
+        }
+
+        if builder.display_height > 0 {
+            rutabaga_builder = rutabaga_builder.set_display_height(builder.display_height);
+        }
+
+        if builder.display_width_mm > 0 {
+            rutabaga_builder = rutabaga_builder.set_display_width_mm(builder.display_width_mm);
+        }
+
+        if builder.display_height_mm > 0 {
+            rutabaga_builder = rutabaga_builder.set_display_height_mm(builder.display_height_mm);
+        }
+
+        let result = rutabaga_builder.build();
 
         let rtbg = return_on_error!(result);
         *ptr = Box::into_raw(Box::new(rtbg)) as _;
@@ -706,6 +748,48 @@ pub extern "C" fn rutabaga_create_fence(ptr: &mut rutabaga, fence: &rutabaga_fen
         return_result(result)
     }))
     .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_gfxstream_get_address_space_device_control_ops() -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| gfxstream_get_address_space_device_control_ops()))
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_gfxstream_set_address_space_hw_funcs(
+    address_space_hw_funcs: *const c_void,
+) -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| {
+        gfxstream_set_address_space_hw_funcs(address_space_hw_funcs)
+    }))
+    .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_gfxstream_get_service_ops() -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| gfxstream_get_service_ops()))
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_gfxstream_set_service_ops(
+    service_ops: *const c_void,
+) -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| {
+        gfxstream_set_service_ops(service_ops)
+    }))
+    .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn rutabaga_gfxstream_set_service_hw_funcs(
+    hw_funcs: *const c_void,
+) -> *const c_void {
+    catch_unwind(AssertUnwindSafe(|| {
+        gfxstream_set_service_hw_funcs(hw_funcs)
+    }))
+    .unwrap_or(std::ptr::null())
 }
 
 /// # Safety

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -791,6 +791,18 @@ pub unsafe extern "C" fn rutabaga_resize_native_surface(
 }
 
 #[no_mangle]
+pub extern "C" fn rutabaga_set_vsync_hz(
+    ptr: &mut rutabaga,
+    vsync_hz: u32,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        ptr.set_vsync_hz(vsync_hz);
+        NO_ERROR
+    }))
+    .unwrap_or(-ESRCH)
+}
+
+#[no_mangle]
 pub extern "C" fn rutabaga_set_scanout_resource(
     ptr: &mut rutabaga,
     scanout_id: u32,

--- a/kumquat/server/src/kumquat_gpu/mod.rs
+++ b/kumquat/server/src/kumquat_gpu/mod.rs
@@ -465,10 +465,8 @@ impl KumquatGpuConnection {
                         },
                     };
 
-                    self.stream.write(KumquatGpuProtocolWrite::CmdWithHandle(
-                        resp,
-                        handle,
-                    ))?;
+                    self.stream
+                        .write(KumquatGpuProtocolWrite::CmdWithHandle(resp, handle))?;
 
                     kumquat_gpu
                         .rutabaga

--- a/src/gfxstream.rs
+++ b/src/gfxstream.rs
@@ -53,20 +53,23 @@ use crate::rutabaga_utils::RutabagaDebugHandler;
 use crate::rutabaga_utils::RutabagaError;
 use crate::rutabaga_utils::RutabagaFence;
 use crate::rutabaga_utils::RutabagaFenceHandler;
-use crate::rutabaga_utils::RutabagaImportData;
 use crate::rutabaga_utils::RutabagaIovec;
 use crate::rutabaga_utils::RutabagaResult;
 use crate::rutabaga_utils::Transfer3D;
 use crate::rutabaga_utils::VulkanInfo;
 use crate::rutabaga_utils::RUTABAGA_FLAG_FENCE_HOST_SHAREABLE;
 use crate::rutabaga_utils::RUTABAGA_HANDLE_TYPE_PLATFORM_AHB;
-use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_RESOURCE_EXISTS;
-use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_VULKAN_INFO;
 use crate::rutabaga_utils::RUTABAGA_MAP_ACCESS_RW;
 #[cfg(gfxstream_unstable)]
 use crate::snapshot::RutabagaSnapshotReader;
 #[cfg(gfxstream_unstable)]
 use crate::snapshot::RutabagaSnapshotWriter;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RutabagaImportData;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_RESOURCE_EXISTS;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_VULKAN_INFO;
 
 // See `virtgpu-gfxstream-renderer.h` for definitions
 const STREAM_RENDERER_PARAM_USER_DATA: u64 = 1;
@@ -76,6 +79,10 @@ const STREAM_RENDERER_PARAM_WIN0_WIDTH: u64 = 4;
 const STREAM_RENDERER_PARAM_WIN0_HEIGHT: u64 = 5;
 const STREAM_RENDERER_PARAM_DEBUG_CALLBACK: u64 = 6;
 const STREAM_RENDERER_PARAM_RENDERER_FEATURES: u64 = 11;
+const STREAM_RENDERER_PARAM_GFXSTREAM_VM_OPS: u64 = 12;
+const STREAM_RENDERER_PARAM_ADDRESS_SPACE_HW_FUNCS: u64 = 13;
+const STREAM_RENDERER_PARAM_DISPLAY_WIDTH_MM: u64 = 14;
+const STREAM_RENDERER_PARAM_DISPLAY_HEIGHT_MM: u64 = 15;
 
 #[cfg(gfxstream_unstable)]
 const STREAM_RENDERER_IMPORT_FLAG_VULKAN_INFO: u32 = RUTABAGA_IMPORT_FLAG_VULKAN_INFO;
@@ -260,6 +267,13 @@ extern "C" {
         import_data: *const stream_renderer_import_data,
     ) -> c_int;
 
+    fn stream_renderer_get_address_space_device_control_ops() -> *const c_void;
+    fn stream_renderer_set_address_space_hw_funcs(hw_funcs: *const c_void) -> *const c_void;
+
+    fn stream_renderer_get_service_ops() -> *const c_void;
+    fn stream_renderer_set_service_ops(ops: *const c_void) -> *const c_void;
+    fn stream_renderer_set_service_hw_funcs(hw_funcs: *const c_void) -> *const c_void;
+
     fn gfxstream_backend_setup_native_surface(
         display_id: u32,
         native_window_handle: *mut c_void,
@@ -303,6 +317,26 @@ extern "C" {
 pub struct Gfxstream {
     /// Cookie used by Gfxstream, should be held as long as the renderer is alive.
     _cookie: Box<RutabagaCookie>,
+}
+
+pub fn gfxstream_get_address_space_device_control_ops() -> *const c_void {
+    unsafe { stream_renderer_get_address_space_device_control_ops() }
+}
+
+pub fn gfxstream_set_address_space_hw_funcs(hw_funcs: *const c_void) -> *const c_void {
+    unsafe { stream_renderer_set_address_space_hw_funcs(hw_funcs) }
+}
+
+pub fn gfxstream_get_service_ops() -> *const c_void {
+    unsafe { stream_renderer_get_service_ops() }
+}
+
+pub fn gfxstream_set_service_ops(ops: *const c_void) -> *const c_void {
+    unsafe { stream_renderer_set_service_ops(ops) }
+}
+
+pub fn gfxstream_set_service_hw_funcs(hw_funcs: *const c_void) -> *const c_void {
+    unsafe { stream_renderer_set_service_hw_funcs(hw_funcs) }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -469,8 +503,12 @@ impl Gfxstream {
     pub fn init(
         display_width: u32,
         display_height: u32,
+        display_width_mm: Option<u32>,
+        display_height_mm: Option<u32>,
         gfxstream_flags: GfxstreamFlags,
         gfxstream_features: Option<String>,
+        gfxstream_vm_ops: Option<*const c_void>,
+        gfxstream_address_space_hw_funcs: Option<*const c_void>,
         fence_handler: RutabagaFenceHandler,
         debug_handler: Option<RutabagaDebugHandler>,
     ) -> RutabagaResult<Box<dyn RutabagaComponent>> {
@@ -507,6 +545,20 @@ impl Gfxstream {
             },
         ]);
 
+        if let Some(display_width_mm) = display_width_mm {
+            stream_renderer_params.push(stream_renderer_param {
+                key: STREAM_RENDERER_PARAM_DISPLAY_WIDTH_MM,
+                value: display_width_mm as u64,
+            });
+        }
+
+        if let Some(display_height_mm) = display_height_mm {
+            stream_renderer_params.push(stream_renderer_param {
+                key: STREAM_RENDERER_PARAM_DISPLAY_HEIGHT_MM,
+                value: display_height_mm as u64,
+            });
+        }
+
         if use_debug {
             stream_renderer_params.push(stream_renderer_param {
                 key: STREAM_RENDERER_PARAM_DEBUG_CALLBACK,
@@ -519,6 +571,20 @@ impl Gfxstream {
             stream_renderer_params.push(stream_renderer_param {
                 key: STREAM_RENDERER_PARAM_RENDERER_FEATURES,
                 value: features_cstr.as_ptr() as u64,
+            });
+        }
+
+        if let Some(gfxstream_vm_ops) = gfxstream_vm_ops {
+            stream_renderer_params.push(stream_renderer_param {
+                key: STREAM_RENDERER_PARAM_GFXSTREAM_VM_OPS,
+                value: gfxstream_vm_ops as u64,
+            });
+        }
+
+        if let Some(gfxstream_address_space_hw_funcs) = gfxstream_address_space_hw_funcs {
+            stream_renderer_params.push(stream_renderer_param {
+                key: STREAM_RENDERER_PARAM_ADDRESS_SPACE_HW_FUNCS,
+                value: gfxstream_address_space_hw_funcs as u64,
             });
         }
 

--- a/src/gfxstream.rs
+++ b/src/gfxstream.rs
@@ -53,23 +53,23 @@ use crate::rutabaga_utils::RutabagaDebugHandler;
 use crate::rutabaga_utils::RutabagaError;
 use crate::rutabaga_utils::RutabagaFence;
 use crate::rutabaga_utils::RutabagaFenceHandler;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RutabagaImportData;
 use crate::rutabaga_utils::RutabagaIovec;
 use crate::rutabaga_utils::RutabagaResult;
 use crate::rutabaga_utils::Transfer3D;
 use crate::rutabaga_utils::VulkanInfo;
 use crate::rutabaga_utils::RUTABAGA_FLAG_FENCE_HOST_SHAREABLE;
 use crate::rutabaga_utils::RUTABAGA_HANDLE_TYPE_PLATFORM_AHB;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_RESOURCE_EXISTS;
+#[cfg(gfxstream_unstable)]
+use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_VULKAN_INFO;
 use crate::rutabaga_utils::RUTABAGA_MAP_ACCESS_RW;
 #[cfg(gfxstream_unstable)]
 use crate::snapshot::RutabagaSnapshotReader;
 #[cfg(gfxstream_unstable)]
 use crate::snapshot::RutabagaSnapshotWriter;
-#[cfg(gfxstream_unstable)]
-use crate::rutabaga_utils::RutabagaImportData;
-#[cfg(gfxstream_unstable)]
-use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_RESOURCE_EXISTS;
-#[cfg(gfxstream_unstable)]
-use crate::rutabaga_utils::RUTABAGA_IMPORT_FLAG_VULKAN_INFO;
 
 // See `virtgpu-gfxstream-renderer.h` for definitions
 const STREAM_RENDERER_PARAM_USER_DATA: u64 = 1;
@@ -1168,8 +1168,14 @@ impl RutabagaComponent for Gfxstream {
     ) -> RutabagaResult<()> {
         let ret = unsafe {
             gfxstream_backend_setup_native_surface(
-                display_id, native_window_handle,
-                width_pt, height_pt, width_px, height_px, dpr)
+                display_id,
+                native_window_handle,
+                width_pt,
+                height_pt,
+                width_px,
+                height_px,
+                dpr,
+            )
         };
         ret_to_res(ret)
     }
@@ -1190,7 +1196,8 @@ impl RutabagaComponent for Gfxstream {
     ) -> RutabagaResult<()> {
         let ret = unsafe {
             gfxstream_backend_resize_native_surface(
-                display_id, width_pt, height_pt, width_px, height_px, dpr)
+                display_id, width_pt, height_pt, width_px, height_px, dpr,
+            )
         };
         ret_to_res(ret)
     }
@@ -1220,9 +1227,8 @@ impl RutabagaComponent for Gfxstream {
         width: u32,
         height: u32,
     ) -> RutabagaResult<bool> {
-        let ret = unsafe {
-            gfxstream_backend_present_flushed_resource(resource_id, x, y, width, height)
-        };
+        let ret =
+            unsafe { gfxstream_backend_present_flushed_resource(resource_id, x, y, width, height) };
         if ret < 0 {
             ret_to_res(ret)?;
         }

--- a/src/gfxstream.rs
+++ b/src/gfxstream.rs
@@ -281,6 +281,8 @@ extern "C" {
         dpr: f32,
     ) -> c_int;
 
+    fn gfxstream_backend_set_vsync_hz(vsync_hz: c_int);
+
     fn gfxstream_backend_set_scanout_resource(
         scanout_id: u32,
         resource_id: u32,
@@ -1124,6 +1126,10 @@ impl RutabagaComponent for Gfxstream {
                 display_id, width_pt, height_pt, width_px, height_px, dpr)
         };
         ret_to_res(ret)
+    }
+
+    fn set_vsync_hz(&self, vsync_hz: u32) {
+        unsafe { gfxstream_backend_set_vsync_hz(vsync_hz as c_int) };
     }
 
     fn set_scanout_resource(

--- a/src/gfxstream.rs
+++ b/src/gfxstream.rs
@@ -517,6 +517,7 @@ impl Gfxstream {
             render_server_fd: None,
             fence_handler: Some(fence_handler),
             debug_handler,
+            #[cfg(feature = "virgl_renderer")]
             rutabaga_paths: None,
         });
 

--- a/src/gfxstream.rs
+++ b/src/gfxstream.rs
@@ -259,6 +259,42 @@ extern "C" {
         import_handle: *const stream_renderer_handle,
         import_data: *const stream_renderer_import_data,
     ) -> c_int;
+
+    fn gfxstream_backend_setup_native_surface(
+        display_id: u32,
+        native_window_handle: *mut c_void,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> c_int;
+
+    fn gfxstream_backend_teardown_native_surface(display_id: u32) -> c_int;
+
+    fn gfxstream_backend_resize_native_surface(
+        display_id: u32,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> c_int;
+
+    fn gfxstream_backend_set_scanout_resource(
+        scanout_id: u32,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> c_int;
+
+    fn gfxstream_backend_present_flushed_resource(
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> c_int;
 }
 
 /// The virtio-gpu backend state tracker which supports accelerated rendering.
@@ -1049,5 +1085,74 @@ impl RutabagaComponent for Gfxstream {
         let ret = unsafe { stream_renderer_resume() };
         ret_to_res(ret)?;
         Ok(())
+    }
+
+    fn setup_native_surface(
+        &self,
+        display_id: u32,
+        native_window_handle: *mut c_void,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> RutabagaResult<()> {
+        let ret = unsafe {
+            gfxstream_backend_setup_native_surface(
+                display_id, native_window_handle,
+                width_pt, height_pt, width_px, height_px, dpr)
+        };
+        ret_to_res(ret)
+    }
+
+    fn teardown_native_surface(&self, display_id: u32) -> RutabagaResult<()> {
+        let ret = unsafe { gfxstream_backend_teardown_native_surface(display_id) };
+        ret_to_res(ret)
+    }
+
+    fn resize_native_surface(
+        &self,
+        display_id: u32,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> RutabagaResult<()> {
+        let ret = unsafe {
+            gfxstream_backend_resize_native_surface(
+                display_id, width_pt, height_pt, width_px, height_px, dpr)
+        };
+        ret_to_res(ret)
+    }
+
+    fn set_scanout_resource(
+        &self,
+        scanout_id: u32,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> RutabagaResult<()> {
+        let ret = unsafe {
+            gfxstream_backend_set_scanout_resource(scanout_id, resource_id, width, height)
+        };
+        ret_to_res(ret)
+    }
+
+    fn present_flushed_resource(
+        &self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> RutabagaResult<bool> {
+        let ret = unsafe {
+            gfxstream_backend_present_flushed_resource(resource_id, x, y, width, height)
+        };
+        if ret < 0 {
+            ret_to_res(ret)?;
+        }
+        Ok(ret > 0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@ pub use mesa3d_util::RawDescriptor as RutabagaRawDescriptor;
 pub use mesa3d_util::MESA_HANDLE_TYPE_MEM_DMABUF as RUTABAGA_HANDLE_TYPE_MEM_DMABUF;
 pub use mesa3d_util::MESA_HANDLE_TYPE_MEM_OPAQUE_FD as RUTABAGA_HANDLE_TYPE_MEM_OPAQUE_FD;
 
+pub use crate::gfxstream::gfxstream_get_address_space_device_control_ops;
+pub use crate::gfxstream::gfxstream_get_service_ops;
+pub use crate::gfxstream::gfxstream_set_address_space_hw_funcs;
+pub use crate::gfxstream::gfxstream_set_service_hw_funcs;
+pub use crate::gfxstream::gfxstream_set_service_ops;
 pub use crate::handle::AhbInfo;
 pub use crate::handle::RutabagaHandle;
 pub use crate::rutabaga_core::calculate_capset_mask;

--- a/src/renderer_utils.rs
+++ b/src/renderer_utils.rs
@@ -10,6 +10,7 @@ use crate::rutabaga_utils::RutabagaDebugHandler;
 use crate::rutabaga_utils::RutabagaError;
 use crate::rutabaga_utils::RutabagaFenceHandler;
 use crate::rutabaga_utils::RutabagaResult;
+#[cfg(feature = "virgl_renderer")]
 use crate::RutabagaPaths;
 
 #[repr(C)]
@@ -36,5 +37,6 @@ pub struct RutabagaCookie {
     pub fence_handler: Option<RutabagaFenceHandler>,
     #[allow(dead_code)]
     pub debug_handler: Option<RutabagaDebugHandler>,
+    #[cfg(feature = "virgl_renderer")]
     pub rutabaga_paths: Option<RutabagaPaths>,
 }

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -1417,6 +1417,8 @@ pub struct RutabagaBuilder {
     fence_handler: RutabagaFenceHandler,
     display_width: u32,
     display_height: u32,
+    display_width_mm: Option<u32>,
+    display_height_mm: Option<u32>,
     default_component: RutabagaComponentType,
     gfxstream_flags: GfxstreamFlags,
     virglrenderer_flags: VirglRendererFlags,
@@ -1424,6 +1426,8 @@ pub struct RutabagaBuilder {
     paths: Option<RutabagaPaths>,
     debug_handler: Option<RutabagaDebugHandler>,
     renderer_features: Option<String>,
+    gfxstream_vm_ops: Option<*const c_void>,
+    gfxstream_address_space_hw_funcs: Option<*const c_void>,
     server_descriptor: Option<OwnedDescriptor>,
 }
 
@@ -1438,6 +1442,8 @@ impl RutabagaBuilder {
             fence_handler,
             display_width: RUTABAGA_DEFAULT_WIDTH,
             display_height: RUTABAGA_DEFAULT_HEIGHT,
+            display_width_mm: None,
+            display_height_mm: None,
             default_component: RutabagaComponentType::NoneSelected,
             gfxstream_flags,
             virglrenderer_flags,
@@ -1445,6 +1451,8 @@ impl RutabagaBuilder {
             paths: None,
             debug_handler: None,
             renderer_features: None,
+            gfxstream_vm_ops: None,
+            gfxstream_address_space_hw_funcs: None,
             server_descriptor: None,
         }
     }
@@ -1458,6 +1466,18 @@ impl RutabagaBuilder {
     /// Set display height for the RutabagaBuilder
     pub fn set_display_height(mut self, display_height: u32) -> RutabagaBuilder {
         self.display_height = display_height;
+        self
+    }
+
+    /// Set physical display width in millimeters for the RutabagaBuilder
+    pub fn set_display_width_mm(mut self, display_width_mm: u32) -> RutabagaBuilder {
+        self.display_width_mm = Some(display_width_mm);
+        self
+    }
+
+    /// Set physical display height in millimeters for the RutabagaBuilder
+    pub fn set_display_height_mm(mut self, display_height_mm: u32) -> RutabagaBuilder {
+        self.display_height_mm = Some(display_height_mm);
         self
     }
 
@@ -1538,6 +1558,24 @@ impl RutabagaBuilder {
     /// Set renderer features for the RutabagaBuilder
     pub fn set_renderer_features(mut self, renderer_features: Option<String>) -> RutabagaBuilder {
         self.renderer_features = renderer_features;
+        self
+    }
+
+    /// Set opaque gfxstream VM ops for the RutabagaBuilder.
+    pub fn set_gfxstream_vm_ops(
+        mut self,
+        gfxstream_vm_ops: Option<*const c_void>,
+    ) -> RutabagaBuilder {
+        self.gfxstream_vm_ops = gfxstream_vm_ops;
+        self
+    }
+
+    /// Set opaque gfxstream address-space HW funcs for the RutabagaBuilder.
+    pub fn set_gfxstream_address_space_hw_funcs(
+        mut self,
+        gfxstream_address_space_hw_funcs: Option<*const c_void>,
+    ) -> RutabagaBuilder {
+        self.gfxstream_address_space_hw_funcs = gfxstream_address_space_hw_funcs;
         self
     }
 
@@ -1646,8 +1684,12 @@ impl RutabagaBuilder {
                 let gfxstream = Gfxstream::init(
                     self.display_width,
                     self.display_height,
+                    self.display_width_mm,
+                    self.display_height_mm,
                     self.gfxstream_flags,
                     self.renderer_features,
+                    self.gfxstream_vm_ops,
+                    self.gfxstream_address_space_hw_funcs,
                     self.fence_handler.clone(),
                     self.debug_handler.clone(),
                 )?;

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -716,8 +716,14 @@ impl Rutabaga {
             .ok_or(RutabagaError::InvalidComponent)?;
 
         component.setup_native_surface(
-            display_id, native_window_handle,
-            width_pt, height_pt, width_px, height_px, dpr)
+            display_id,
+            native_window_handle,
+            width_pt,
+            height_pt,
+            width_px,
+            height_px,
+            dpr,
+        )
     }
 
     pub fn teardown_native_surface(&self, display_id: u32) -> RutabagaResult<()> {

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap as Map;
 use std::convert::TryInto;
 use std::io::IoSlice;
 use std::io::IoSliceMut;
+use std::os::raw::c_void;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -373,6 +374,56 @@ pub trait RutabagaComponent {
     fn resume(&self) -> RutabagaResult<()> {
         Ok(())
     }
+
+    fn setup_native_surface(
+        &self,
+        _display_id: u32,
+        _native_window_handle: *mut c_void,
+        _width_pt: i32,
+        _height_pt: i32,
+        _width_px: i32,
+        _height_px: i32,
+        _dpr: f32,
+    ) -> RutabagaResult<()> {
+        Err(MesaError::Unsupported.into())
+    }
+
+    fn teardown_native_surface(&self, _display_id: u32) -> RutabagaResult<()> {
+        Err(MesaError::Unsupported.into())
+    }
+
+    fn resize_native_surface(
+        &self,
+        _display_id: u32,
+        _width_pt: i32,
+        _height_pt: i32,
+        _width_px: i32,
+        _height_px: i32,
+        _dpr: f32,
+    ) -> RutabagaResult<()> {
+        Err(MesaError::Unsupported.into())
+    }
+
+    fn set_scanout_resource(
+        &self,
+        _scanout_id: u32,
+        _resource_id: u32,
+        _width: u32,
+        _height: u32,
+    ) -> RutabagaResult<()> {
+        Err(MesaError::Unsupported.into())
+    }
+
+    fn present_flushed_resource(
+        &self,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> RutabagaResult<bool> {
+        Err(MesaError::Unsupported.into())
+    }
 }
 
 pub trait RutabagaContext {
@@ -645,6 +696,83 @@ impl Rutabaga {
             .ok_or(RutabagaError::InvalidComponent)?;
 
         component.resume()
+    }
+
+    pub fn setup_native_surface(
+        &self,
+        display_id: u32,
+        native_window_handle: *mut c_void,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> RutabagaResult<()> {
+        let component = self
+            .components
+            .get(&self.default_component)
+            .ok_or(RutabagaError::InvalidComponent)?;
+
+        component.setup_native_surface(
+            display_id, native_window_handle,
+            width_pt, height_pt, width_px, height_px, dpr)
+    }
+
+    pub fn teardown_native_surface(&self, display_id: u32) -> RutabagaResult<()> {
+        let component = self
+            .components
+            .get(&self.default_component)
+            .ok_or(RutabagaError::InvalidComponent)?;
+
+        component.teardown_native_surface(display_id)
+    }
+
+    pub fn resize_native_surface(
+        &self,
+        display_id: u32,
+        width_pt: i32,
+        height_pt: i32,
+        width_px: i32,
+        height_px: i32,
+        dpr: f32,
+    ) -> RutabagaResult<()> {
+        let component = self
+            .components
+            .get(&self.default_component)
+            .ok_or(RutabagaError::InvalidComponent)?;
+
+        component.resize_native_surface(display_id, width_pt, height_pt, width_px, height_px, dpr)
+    }
+
+    pub fn set_scanout_resource(
+        &self,
+        scanout_id: u32,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> RutabagaResult<()> {
+        let component = self
+            .components
+            .get(&self.default_component)
+            .ok_or(RutabagaError::InvalidComponent)?;
+
+        component.set_scanout_resource(scanout_id, resource_id, width, height)
+    }
+
+    pub fn present_flushed_resource(
+        &self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> RutabagaResult<bool> {
+        let component = self
+            .components
+            .get(&self.default_component)
+            .ok_or(RutabagaError::InvalidComponent)?;
+
+        component.present_flushed_resource(resource_id, x, y, width, height)
     }
 
     fn capset_id_to_component_type(&self, capset_id: u32) -> RutabagaResult<RutabagaComponentType> {

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -404,6 +404,8 @@ pub trait RutabagaComponent {
         Err(MesaError::Unsupported.into())
     }
 
+    fn set_vsync_hz(&self, _vsync_hz: u32) {}
+
     fn set_scanout_resource(
         &self,
         _scanout_id: u32,
@@ -742,6 +744,12 @@ impl Rutabaga {
             .ok_or(RutabagaError::InvalidComponent)?;
 
         component.resize_native_surface(display_id, width_pt, height_pt, width_px, height_px, dpr)
+    }
+
+    pub fn set_vsync_hz(&self, vsync_hz: u32) {
+        if let Some(component) = self.components.get(&self.default_component) {
+            component.set_vsync_hz(vsync_hz);
+        }
     }
 
     pub fn set_scanout_resource(

--- a/src/rutabaga_utils.rs
+++ b/src/rutabaga_utils.rs
@@ -649,7 +649,6 @@ pub const RUTABAGA_HANDLE_TYPE_PLATFORM_SCREEN_BUFFER_QNX: u32 = 0x01000000;
 pub const RUTABAGA_HANDLE_TYPE_PLATFORM_EGL_NATIVE_PIXMAP: u32 = 0x02000000;
 pub const RUTABAGA_HANDLE_TYPE_PLATFORM_AHB: u32 = 0x03000000;
 
-
 #[derive(Clone)]
 pub struct RutabagaHandler<S> {
     closure: Arc<dyn Fn(S) + Send + Sync>,

--- a/src/virgl_renderer.rs
+++ b/src/virgl_renderer.rs
@@ -23,6 +23,7 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::panic::catch_unwind;
 use std::process::abort;
 use std::ptr::null_mut;
+use std::ptr::NonNull;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -73,6 +74,8 @@ use crate::RUTABAGA_PATH_TYPE_GPU;
 
 type Query = virgl_renderer_export_query;
 
+static VIRGL_INIT_ONCE: AtomicBool = AtomicBool::new(false);
+
 /// Default drm fd, returning this indicates that virglrenderer should
 /// find an available GPU itself.
 const DEFAULT_DRM_FD: i32 = -1;
@@ -107,7 +110,9 @@ fn dup(rd: RawDescriptor) -> RutabagaResult<OwnedDescriptor> {
 }
 
 /// The virtio-gpu backend state tracker which supports accelerated rendering.
-pub struct VirglRenderer {}
+pub struct VirglRenderer {
+    cookie: NonNull<RutabagaCookie>,
+}
 
 struct VirglRendererContext {
     ctx_id: u32,
@@ -436,9 +441,8 @@ impl VirglRenderer {
         // virglrenderer is a global state backed library that uses thread bound OpenGL contexts.
         // Initialize it only once and use the non-send/non-sync Renderer struct to keep things tied
         // to whichever thread called this function first.
-        static INIT_ONCE: AtomicBool = AtomicBool::new(false);
-        if INIT_ONCE
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Acquire)
+        if VIRGL_INIT_ONCE
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
             return Err(RutabagaError::AlreadyInUse);
@@ -450,31 +454,35 @@ impl VirglRenderer {
             virgl_set_log_callback(Some(log_callback), null_mut(), None);
         };
 
-        // Cookie is intentionally never freed because virglrenderer never gets uninitialized.
-        // Otherwise, Resource and Context would become invalid because their lifetime is not tied
-        // to the Renderer instance. Doing so greatly simplifies the ownership for users of this
-        // library.
-        let cookie = Box::into_raw(Box::new(RutabagaCookie {
+        // Keep the callback cookie alive for the lifetime of the virglrenderer instance so
+        // callbacks can safely access it, then reclaim it during cleanup.
+        let cookie = NonNull::from(Box::leak(Box::new(RutabagaCookie {
             render_server_fd,
             fence_handler: Some(fence_handler),
             debug_handler: None,
             rutabaga_paths,
-        }));
+        })));
 
         // SAFETY:
         // Safe because a valid cookie and set of callbacks is used and the result is checked for
         // error.
         let ret = unsafe {
             virgl_renderer_init(
-                cookie as *mut c_void,
+                cookie.as_ptr() as *mut c_void,
                 virglrenderer_flags.into(),
                 VIRGL_RENDERER_CALLBACKS as *const virgl_renderer_callbacks
                     as *mut virgl_renderer_callbacks,
             )
         };
 
-        ret_to_res(ret)?;
-        Ok(Box::new(VirglRenderer {}))
+        if let Err(e) = ret_to_res(ret) {
+            unsafe {
+                drop(Box::from_raw(cookie.as_ptr()));
+            }
+            VIRGL_INIT_ONCE.store(false, Ordering::Release);
+            return Err(e);
+        }
+        Ok(Box::new(VirglRenderer { cookie }))
     }
 
     fn map_info(&self, resource_id: u32) -> RutabagaResult<u32> {
@@ -546,8 +554,10 @@ impl Drop for VirglRenderer {
         // makes sure contexts and resources are dropped before this is reached.  Even if it did
         // not, virglrenderer is designed to deal with invalid ids safely.
         unsafe {
-            virgl_renderer_cleanup(null_mut());
+            virgl_renderer_cleanup(self.cookie.as_ptr() as *mut c_void);
+            drop(Box::from_raw(self.cookie.as_ptr()));
         }
+        VIRGL_INIT_ONCE.store(false, Ordering::Release);
     }
 }
 

--- a/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
@@ -1,8 +1,8 @@
 // Copyright 2025 Google
 // SPDX-License-Identifier: MIT
 
-use std::fs::File;
 use std::fs::read_link;
+use std::fs::File;
 use std::io::Error;
 use std::io::ErrorKind;
 use std::io::Result;

--- a/third_party/mesa3d/src/virtio/virtgpu_kumquat/Cargo.toml
+++ b/third_party/mesa3d/src/virtio/virtgpu_kumquat/Cargo.toml
@@ -13,7 +13,3 @@ path = "lib.rs"
 [dependencies]
 mesa3d_util = {path = "../../util/rust", version = "0.1.76"}
 mesa3d_protocols = { path = "../protocols", version = "0.1.76"}
-
-[profile.dev]
-lto = true
-incremental = false


### PR DESCRIPTION
## Summary
- enable `STREAM_RENDERER_FLAGS_USE_EXTERNAL_BLOB` during gfxstream init for macOS/Metal blob mappings
- expose native surface, Vulkan swapchain WSI, and dynamic vsync APIs through the Rust and C FFI layers
- forward gfxstream VM ops, address-space callbacks, service ops, and display millimeter fields through initialization
- clean up gfxstream/virgl feature gating and related kumquat configuration

## Validation
- attempted `cargo test --workspace`
- blocked locally because the pinned `cargo 1.81.0` toolchain cannot parse the downloaded `clap v4.6.0` manifest, which now requires `edition2024`
