### PR TITLE
libkrun/cross_domain: Pass the eventfd read() result to the guest

### DIFF
--- a/src/cross_domain/atomic_memory_sentinel_manager.rs
+++ b/src/cross_domain/atomic_memory_sentinel_manager.rs
@@ -192,10 +192,10 @@ impl AtomicMemorySentinelManager {
 
     /// Handles an event for a memory watcher, returns the command to write to the ring
     pub fn handle_event(
-        &self,
+        &mut self,
         id: u32,
     ) -> RutabagaResult<Option<CrossDomainSignalAtomicMemorySentinel>> {
-        if let Some(watcher) = self.watchers.get(&id) {
+        if let Some(watcher) = self.watchers.get_mut(&id) {
             if watcher.is_shutdown() {
                 Ok(None)
             } else {

--- a/src/cross_domain/mod.rs
+++ b/src/cross_domain/mod.rs
@@ -321,7 +321,7 @@ impl CrossDomainWorker {
     fn handle_fence(
         &mut self,
         fence: RutabagaFence,
-        thread_resample_evt: &Event,
+        thread_resample_evt: &mut Event,
         receive_buf: &mut [u8],
     ) -> RutabagaResult<()> {
         let events = self.wait_ctx.wait(WaitTimeout::NoTimeout)?;
@@ -521,7 +521,11 @@ impl CrossDomainWorker {
         Ok(())
     }
 
-    fn run(&mut self, thread_kill_evt: Event, thread_resample_evt: Event) -> RutabagaResult<()> {
+    fn run(
+        &mut self,
+        thread_kill_evt: Event,
+        mut thread_resample_evt: Event,
+    ) -> RutabagaResult<()> {
         self.wait_ctx.add(
             CROSS_DOMAIN_RESAMPLE_ID,
             thread_resample_evt.as_borrowed_descriptor(),
@@ -535,7 +539,7 @@ impl CrossDomainWorker {
         while let Some(job) = self.state.wait_for_job() {
             match job {
                 CrossDomainJob::HandleFence(fence) => {
-                    match self.handle_fence(fence, &thread_resample_evt, &mut receive_buf) {
+                    match self.handle_fence(fence, &mut thread_resample_evt, &mut receive_buf) {
                         Ok(()) => (),
                         Err(e) => {
                             error!("Worker halting due to: {}", e);

--- a/src/cross_domain/mod.rs
+++ b/src/cross_domain/mod.rs
@@ -99,6 +99,7 @@ enum CrossDomainJob {
 enum RingWrite<'a, T> {
     Write(T, Option<&'a [u8]>),
     WriteFromPipe(CrossDomainReadWrite, &'a mut ReadPipe, bool),
+    WriteFromEvent(CrossDomainReadWrite, &'a mut Event, bool),
 }
 
 type CrossDomainJobs = Mutex<Option<VecDeque<CrossDomainJob>>>;
@@ -295,6 +296,24 @@ impl CrossDomainState {
                     bytes_read.try_into().map_err(MesaError::TryFromIntError)?;
                 cmd_slice.copy_from_slice(cmd_read.as_bytes());
             }
+            RingWrite::WriteFromEvent(mut cmd_read, ref mut event, readable) => {
+                if slice.len() < size_of::<CrossDomainReadWrite>() {
+                    return Err(RutabagaError::InvalidIovec);
+                }
+
+                let (cmd_slice, opaque_data_slice) =
+                    slice.split_at_mut(size_of::<CrossDomainReadWrite>());
+
+                if readable {
+                    let value = event.wait()?;
+                    bytes_read = 8;
+                    opaque_data_slice[0..8].copy_from_slice(&value.to_ne_bytes());
+                }
+
+                cmd_read.opaque_data_size =
+                    bytes_read.try_into().map_err(MesaError::TryFromIntError)?;
+                cmd_slice.copy_from_slice(cmd_read.as_bytes());
+            }
         }
 
         Ok(bytes_read)
@@ -426,12 +445,13 @@ impl CrossDomainWorker {
                                 self.wait_ctx.delete(readpipe.as_borrowed_descriptor())?;
                             }
                         }
-                        CrossDomainItem::Event(ref evt) => {
-                            // For eventfd, we can use wait() to consume the event
-                            if event.readable {
-                                let _ = evt.wait();
-                            }
-                            bytes_read = 0; // eventfd doesn't have data to read like pipes
+                        CrossDomainItem::Event(ref mut evt) => {
+                            let ring_write =
+                                RingWrite::WriteFromEvent(cmd_read, evt, event.readable);
+                            bytes_read = self.state.write_to_ring::<CrossDomainReadWrite>(
+                                ring_write,
+                                self.state.channel_ring_id,
+                            )?;
                         }
                         _ => return Err(RutabagaError::InvalidCrossDomainItemType),
                     }

--- a/third_party/mesa3d/src/util/rust/sys/linux/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/event.rs
@@ -27,14 +27,19 @@ impl Event {
         })
     }
 
-    pub fn signal(&mut self) -> MesaResult<()> {
-        let _ = write(&self.descriptor, &1u64.to_ne_bytes())?;
+    pub fn add(&mut self, value: u64) -> MesaResult<()> {
+        let _ = write(&self.descriptor, &value.to_ne_bytes())?;
         Ok(())
     }
 
-    pub fn wait(&self) -> MesaResult<()> {
-        read(&self.descriptor, &mut 1u64.to_ne_bytes())?;
-        Ok(())
+    pub fn signal(&mut self) -> MesaResult<()> {
+        self.add(1)
+    }
+
+    pub fn wait(&mut self) -> MesaResult<u64> {
+        let mut buf = [0; 8];
+        read(&self.descriptor, &mut buf)?;
+        Ok(u64::from_ne_bytes(buf))
     }
 
     pub fn try_clone(&self) -> MesaResult<Event> {

--- a/third_party/mesa3d/src/util/rust/sys/stub/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/event.rs
@@ -14,11 +14,15 @@ impl Event {
         Err(MesaError::Unsupported)
     }
 
+    pub fn add(&mut self, value: u64) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
     pub fn signal(&mut self) -> MesaResult<()> {
         Err(MesaError::Unsupported)
     }
 
-    pub fn wait(&self) -> MesaResult<()> {
+    pub fn wait(&mut self) -> MesaResult<u64> {
         Err(MesaError::Unsupported)
     }
 

--- a/third_party/mesa3d/src/util/rust/sys/windows/event.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/event.rs
@@ -14,11 +14,15 @@ impl Event {
         Err(MesaError::Unsupported)
     }
 
+    pub fn add(&mut self, value: u64) -> MesaResult<()> {
+        Err(MesaError::Unsupported)
+    }
+
     pub fn signal(&mut self) -> MesaResult<()> {
         Err(MesaError::Unsupported)
     }
 
-    pub fn wait(&self) -> MesaResult<()> {
+    pub fn wait(&mut self) -> MesaResult<u64> {
         Err(MesaError::Unsupported)
     }
 

--- a/third_party/mesa3d/src/virtio/virtgpu_kumquat/virtgpu_kumquat.rs
+++ b/third_party/mesa3d/src/virtio/virtgpu_kumquat/virtgpu_kumquat.rs
@@ -518,7 +518,7 @@ impl VirtGpuKumquat {
 
         let new_fences: Vec<MesaHandle> = std::mem::take(&mut resource.attached_fences);
         for fence in new_fences {
-            let event: Event = fence.try_into()?;
+            let mut event: Event = fence.try_into()?;
             event.wait()?;
         }
 


### PR DESCRIPTION
We *can't* just use wait() to consume the event… eventfd *does* have data to return, the current value of the counter :) PipeWire was broken because of this.

I've tried to keep backwards compat in the mesa3d API (and added a write-with-value for symmetry), but if you have any thoughts on how that whole thing should be changed tell me..