### PR TITLE
Support fd-passing proxied sockets

### DIFF
--- a/src/cross_domain/cross_domain_protocol.rs
+++ b/src/cross_domain/cross_domain_protocol.rs
@@ -24,6 +24,7 @@ pub const CROSS_DOMAIN_CMD_SIGNAL_ATOMIC_MEMORY_SENTINEL: u8 = 9;
 pub const CROSS_DOMAIN_CMD_DESTROY_ATOMIC_MEMORY_SENTINEL: u8 = 10;
 pub const CROSS_DOMAIN_CMD_READ_CREATE_EVENT: u8 = 11;
 pub const CROSS_DOMAIN_CMD_IMPORT_VIRTIOFS_HANDLE: u8 = 12;
+pub const CROSS_DOMAIN_CMD_ASSIGN_SOCKET_UUID: u8 = 13;
 
 /// Channel types (must match rutabaga channel types)
 pub const CROSS_DOMAIN_CHANNEL_TYPE_WAYLAND: u32 = 0x0001;
@@ -32,6 +33,7 @@ pub const CROSS_DOMAIN_CHANNEL_TYPE_PIPEWIRE: u32 = 0x0010;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_X11: u32 = 0x0011;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_DBUS_SESSION: u32 = 0x0012;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_DBUS_SYSTEM: u32 = 0x0013;
+pub const CROSS_DOMAIN_CHANNEL_TYPE_INTERNAL_SOCKET: u32 = u32::MAX;
 
 /// The maximum number of identifiers
 pub const CROSS_DOMAIN_MAX_IDENTIFIERS: usize = 28;
@@ -50,6 +52,7 @@ pub const CROSS_DOMAIN_ID_TYPE_WRITE_PIPE: u32 = 4;
 pub const CROSS_DOMAIN_ID_TYPE_EVENT: u32 = 5;
 
 pub const CROSS_DOMAIN_ID_TYPE_VIRTIO_FS_BLOB: u32 = 6;
+pub const CROSS_DOMAIN_ID_TYPE_SOCKET: u32 = 7;
 
 /// No ring
 pub const CROSS_DOMAIN_RING_NONE: u32 = 0xffffffff;
@@ -101,6 +104,7 @@ pub struct CrossDomainInit {
     pub query_ring_id: u32,
     pub channel_ring_id: u32,
     pub channel_type: u32,
+    pub internal_socket_uuid: [u8; 16],
 }
 
 #[repr(C)]
@@ -179,6 +183,15 @@ pub struct CrossDomainImportVirtioFsHandle {
     pub hdr: CrossDomainHeader,
     pub fs_id: u64,
     pub handle: u64,
+    pub id: u32,
+    pub pad: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
+pub struct CrossDomainAssignSocketUuid {
+    pub hdr: CrossDomainHeader,
+    pub socket_uuid: [u8; 16],
     pub id: u32,
     pub pad: u32,
 }

--- a/src/cross_domain/mod.rs
+++ b/src/cross_domain/mod.rs
@@ -86,6 +86,7 @@ enum CrossDomainItem {
     WaylandWritePipe(WritePipe),
     Event(Event),
     RegularFile(OwnedDescriptor),
+    Socket(OwnedDescriptor),
 }
 
 enum CrossDomainJob {
@@ -137,6 +138,7 @@ struct CrossDomainContext {
     sentinel_manager: SentinelManager,
     fence_handler: RutabagaFenceHandler,
     virtiofs_lookup: Option<Arc<dyn VirtioFsLookup>>,
+    internal_sockets: Arc<Mutex<Map<u128, Tube>>>,
     worker_thread: Option<thread::JoinHandle<RutabagaResult<()>>>,
     resample_evt: Option<Event>,
     kill_evt: Option<Event>,
@@ -148,6 +150,7 @@ pub struct CrossDomain {
     paths: Option<Vec<RutabagaPath>>,
     gralloc: Arc<Mutex<RutabagaGralloc>>,
     fence_handler: RutabagaFenceHandler,
+    internal_sockets: Arc<Mutex<Map<u128, Tube>>>,
     virtiofs_lookup: Option<Arc<dyn VirtioFsLookup>>,
 }
 
@@ -508,6 +511,11 @@ impl CrossDomainWorker {
                             CrossDomainItem::WaylandWritePipe(write_pipe),
                         );
                     }
+                    DescriptorType::Socket(_) => {
+                        *identifier_type = CROSS_DOMAIN_ID_TYPE_SOCKET;
+                        *identifier_size = 0;
+                        *identifier = add_item(&self.item_state, CrossDomainItem::Socket(file));
+                    }
                     _ => return Err(RutabagaError::InvalidCrossDomainItemType),
                 }
             }
@@ -596,6 +604,7 @@ impl CrossDomain {
             paths,
             gralloc: Arc::new(Mutex::new(gralloc)),
             fence_handler,
+            internal_sockets: Arc::new(Mutex::new(Map::new())),
             virtiofs_lookup,
         }))
     }
@@ -615,6 +624,15 @@ impl CrossDomainContext {
 
         let tube = Tube::new(path.clone(), TubeType::Stream)?;
         Ok(tube)
+    }
+
+    fn get_internal_socket_connection(&mut self, uuid: u128) -> RutabagaResult<Tube> {
+        let mut sockets = self.internal_sockets.lock().unwrap();
+        let socket = sockets
+            .remove(&uuid)
+            .ok_or(RutabagaError::InvalidCrossDomainInternalSocketUuid)?;
+
+        Ok(socket)
     }
 
     fn initialize(&mut self, cmd_init: &CrossDomainInit) -> RutabagaResult<()> {
@@ -643,7 +661,13 @@ impl CrossDomainContext {
                 return Err(RutabagaError::InvalidResourceId);
             }
 
-            let connection = self.get_connection(cmd_init)?;
+            let connection = if cmd_init.channel_type == CROSS_DOMAIN_CHANNEL_TYPE_INTERNAL_SOCKET {
+                self.get_internal_socket_connection(u128::from_le_bytes(
+                    cmd_init.internal_socket_uuid,
+                ))?
+            } else {
+                self.get_connection(cmd_init)?
+            };
 
             let kill_evt = Event::new()?;
             let thread_kill_evt = kill_evt.try_clone()?;
@@ -926,6 +950,29 @@ impl CrossDomainContext {
         Ok(())
     }
 
+    fn socket_assign_uuid(
+        &mut self,
+        cmd_exp_socket: &CrossDomainAssignSocketUuid,
+    ) -> RutabagaResult<()> {
+        let mut items = self.item_state.lock().unwrap();
+
+        let item = items
+            .table
+            .remove(&cmd_exp_socket.id)
+            .ok_or(RutabagaError::InvalidCrossDomainItemId)?;
+
+        if let CrossDomainItem::Socket(fd) = item {
+            let mut sockets = self.internal_sockets.lock().unwrap();
+            sockets.insert(
+                u128::from_ne_bytes(cmd_exp_socket.socket_uuid),
+                Tube::try_from(fd)?,
+            );
+            Ok(())
+        } else {
+            Err(RutabagaError::InvalidCrossDomainItemType)
+        }
+    }
+
     fn write(&self, cmd_write: &CrossDomainReadWrite, opaque_data: &[u8]) -> RutabagaResult<()> {
         let mut items = self.item_state.lock().unwrap();
 
@@ -1013,6 +1060,28 @@ impl CrossDomainInitLegacy {
             query_ring_id: self.query_ring_id,
             channel_ring_id: self.query_ring_id,
             channel_type: self.channel_type,
+            internal_socket_uuid: [0; 16],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
+pub struct CrossDomainInitV1 {
+    pub hdr: CrossDomainHeader,
+    pub query_ring_id: u32,
+    pub channel_ring_id: u32,
+    pub channel_type: u32,
+}
+
+impl CrossDomainInitV1 {
+    pub(crate) fn upgrade(&self) -> CrossDomainInit {
+        CrossDomainInit {
+            hdr: self.hdr,
+            query_ring_id: self.query_ring_id,
+            channel_ring_id: self.channel_ring_id,
+            channel_type: self.channel_type,
+            internal_socket_uuid: [0; 16],
         }
     }
 }
@@ -1123,14 +1192,23 @@ impl RutabagaContext for CrossDomainContext {
                 .map_err(|_| RutabagaError::InvalidCommandBuffer)?;
 
             match hdr.cmd {
-                CROSS_DOMAIN_CMD_INIT => {
-                    let cmd_init = CrossDomainInit::read_from_prefix(commands)
-                        .map(|(v, _)| v)
-                        .or_else(|_| {
-                            CrossDomainInitLegacy::read_from_prefix(commands)
-                                .map(|(v, _)| v.upgrade())
-                        })
-                        .map_err(|_| RutabagaError::InvalidCommandBuffer)?;
+                CROSS_DOMAIN_CMD_INIT
+                    if hdr.cmd_size as usize == size_of::<CrossDomainInitLegacy>() =>
+                {
+                    let (cmd_init, _) = CrossDomainInitLegacy::read_from_prefix(commands)
+                        .map_err(|_e| RutabagaError::InvalidCommandBuffer)?;
+                    self.initialize(&cmd_init.upgrade())?;
+                }
+                CROSS_DOMAIN_CMD_INIT
+                    if hdr.cmd_size as usize == size_of::<CrossDomainInitV1>() =>
+                {
+                    let (cmd_init, _) = CrossDomainInitV1::read_from_prefix(commands)
+                        .map_err(|_e| RutabagaError::InvalidCommandBuffer)?;
+                    self.initialize(&cmd_init.upgrade())?;
+                }
+                CROSS_DOMAIN_CMD_INIT if hdr.cmd_size as usize == size_of::<CrossDomainInit>() => {
+                    let (cmd_init, _) = CrossDomainInit::read_from_prefix(commands)
+                        .map_err(|_e| RutabagaError::InvalidCommandBuffer)?;
                     self.initialize(&cmd_init)?;
                 }
                 CROSS_DOMAIN_CMD_GET_IMAGE_REQUIREMENTS => {
@@ -1184,6 +1262,12 @@ impl RutabagaContext for CrossDomainContext {
                     let (cmd_new_evt, _) = CrossDomainCreateEvent::read_from_prefix(commands)
                         .map_err(|_| RutabagaError::InvalidCommandBuffer)?;
                     self.read_event_new(&cmd_new_evt)?;
+                }
+                CROSS_DOMAIN_CMD_ASSIGN_SOCKET_UUID => {
+                    let (cmd_exp_socket, _) =
+                        CrossDomainAssignSocketUuid::read_from_prefix(commands.as_bytes())
+                            .map_err(|_| RutabagaError::InvalidCommandBuffer)?;
+                    self.socket_assign_uuid(&cmd_exp_socket)?;
                 }
                 CROSS_DOMAIN_CMD_IMPORT_VIRTIOFS_HANDLE => {
                     let (cmd_imp_handle, _) =
@@ -1323,6 +1407,7 @@ impl RutabagaComponent for CrossDomain {
             ))),
             fence_handler,
             virtiofs_lookup: self.virtiofs_lookup.clone(),
+            internal_sockets: self.internal_sockets.clone(),
             worker_thread: None,
             resample_evt: None,
             kill_evt: None,

--- a/src/rutabaga_utils.rs
+++ b/src/rutabaga_utils.rs
@@ -271,6 +271,9 @@ pub enum RutabagaError {
     /// Invalid cross domain channel
     #[error("invalid cross domain channel")]
     InvalidCrossDomainChannel,
+    /// Invalid cross domain internal socket UUID
+    #[error("invalid cross domain internal socket UUID")]
+    InvalidCrossDomainInternalSocketUuid,
     /// Invalid cross domain item ID
     #[error("invalid cross domain item id")]
     InvalidCrossDomainItemId,

--- a/third_party/mesa3d/src/util/rust/defines.rs
+++ b/third_party/mesa3d/src/util/rust/defines.rs
@@ -89,6 +89,7 @@ pub enum DescriptorType {
     Memory(u32, u32), // (size, handle_type)
     WritePipe,
     Event,
+    Socket(TubeType),
 }
 
 /// # Safety

--- a/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/descriptor.rs
@@ -15,14 +15,19 @@ use std::os::unix::io::IntoRawFd;
 use std::os::unix::io::RawFd;
 
 use rustix::fs::fcntl_getfl;
+use rustix::fs::fstat;
 use rustix::fs::seek;
+use rustix::fs::FileType;
 use rustix::fs::OFlags;
 use rustix::fs::SeekFrom;
+use rustix::net::sockopt::socket_type;
+use rustix::net::SocketType;
 
 use crate::descriptor::AsRawDescriptor;
 use crate::descriptor::FromRawDescriptor;
 use crate::descriptor::IntoRawDescriptor;
 use crate::DescriptorType;
+use crate::TubeType;
 use crate::MESA_HANDLE_TYPE_MEM_DMABUF;
 use crate::MESA_HANDLE_TYPE_MEM_SHM;
 
@@ -46,6 +51,20 @@ impl OwnedDescriptor {
             let path_str = fd_path.to_string_lossy();
             if path_str.starts_with("anon_inode:[eventfd]") {
                 return Ok(DescriptorType::Event);
+            }
+        }
+
+        if let Ok(fd_stat) = fstat(&self.owned) {
+            let fd_type = FileType::from_raw_mode(fd_stat.st_mode);
+            if fd_type == FileType::Socket {
+                return Ok(DescriptorType::Socket(match socket_type(&self.owned)? {
+                    SocketType::SEQPACKET => TubeType::Packet,
+                    SocketType::STREAM => TubeType::Stream,
+                    ty => {
+                        log::warn!("Unsupported socket type {ty:?}");
+                        return Err(Error::from(ErrorKind::Unsupported));
+                    }
+                }));
             }
         }
 

--- a/third_party/mesa3d/src/util/rust/sys/linux/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/linux/tube.rs
@@ -17,6 +17,7 @@ use rustix::net::listen;
 use rustix::net::recvmsg;
 use rustix::net::sendmsg;
 use rustix::net::socket_with;
+use rustix::net::sockopt::socket_type;
 use rustix::net::AddressFamily;
 use rustix::net::RecvAncillaryBuffer;
 use rustix::net::RecvAncillaryMessage;
@@ -39,6 +40,19 @@ const MAX_IDENTIFIERS: usize = 28;
 
 pub struct Tube {
     socket: OwnedDescriptor,
+}
+
+impl TryFrom<OwnedDescriptor> for Tube {
+    type Error = MesaError;
+
+    fn try_from(socket: OwnedDescriptor) -> Result<Self, Self::Error> {
+        let ty = socket_type(&socket)?;
+        if ty == SocketType::SEQPACKET || ty == SocketType::STREAM {
+            Ok(Tube { socket })
+        } else {
+            Err(MesaError::Unsupported)
+        }
+    }
 }
 
 impl Tube {

--- a/third_party/mesa3d/src/util/rust/sys/stub/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/stub/tube.rs
@@ -12,6 +12,14 @@ use crate::TubeType;
 pub struct Tube;
 pub struct Listener;
 
+impl TryFrom<OwnedDescriptor> for Tube {
+    type Error = MesaError;
+
+    fn try_from(_socket: OwnedDescriptor) -> Result<Self, Self::Error> {
+        Err(MesaError::Unsupported)
+    }
+}
+
 impl Tube {
     pub fn new<P: AsRef<Path>>(_path: P, _kind: TubeType) -> MesaResult<Tube> {
         Err(MesaError::Unsupported)

--- a/third_party/mesa3d/src/util/rust/sys/windows/tube.rs
+++ b/third_party/mesa3d/src/util/rust/sys/windows/tube.rs
@@ -12,6 +12,14 @@ use crate::TubeType;
 pub struct Tube;
 pub struct Listener;
 
+impl TryFrom<OwnedDescriptor> for Tube {
+    type Error = MesaError;
+
+    fn try_from(_socket: OwnedDescriptor) -> Result<Self, Self::Error> {
+        Err(MesaError::Unsupported)
+    }
+}
+
 impl Tube {
     pub fn new<P: AsRef<Path>>(_path: P, _kind: TubeType) -> MesaResult<Tube> {
         Err(MesaError::Unsupported)


### PR DESCRIPTION
This allows for things like [Camera](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Camera.html)/[ScreenCast](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html) portals (which pass authorized PipeWire sockets over D-Bus) to be exposed to a guest. The flow is basically:

- host receives a socket fd on behalf of the "parent" protocol (e.g. dbus) proxy, it is added as a `CrossDomainItem` as usual
- the proxy receives the item handle, and if it decides to proceed, generates a unique key (token) and calls the new `EXPORT_SOCKET` command to register the fd in a global table under that key
- then that proxy can pass the token to a "child" protocol proxy (e.g. pipewire) that it spawns
- the "child" proxy uses the token in an extended version of the `CrossDomainInit` command to tell rutabaga to import the previously exported socket from the global table instead of creating a new connection by path
- everyone is happy :)

Generating the token is the responsibility of the guest because 1. it's easier to not return data from the command, and 2. in order to avoid adding a dependency for getrandom/etc.

---

The PR is rebased to be directly on top of the libkrun branch but the constant numbers skip one because it was originally on top of #47 which uses those numbers.