### PR TITLE
cross_domain: Allow writing to eventfds

### DIFF
--- a/src/cross_domain/mod.rs
+++ b/src/cross_domain/mod.rs
@@ -1027,6 +1027,21 @@ impl CrossDomainContext {
 
                 Ok(())
             }
+            CrossDomainItem::Event(mut event) => {
+                let Ok(bytes) = <[u8; 8]>::try_from(opaque_data) else {
+                    return Err(RutabagaError::InvalidCrossDomainWriteLength);
+                };
+
+                event.add(u64::from_ne_bytes(bytes))?;
+
+                if cmd_write.hang_up == 0 {
+                    items
+                        .table
+                        .insert(cmd_write.identifier, CrossDomainItem::Event(event));
+                }
+
+                Ok(())
+            }
             _ => Err(RutabagaError::InvalidCrossDomainItemType),
         }
     }

--- a/src/rutabaga_utils.rs
+++ b/src/rutabaga_utils.rs
@@ -283,6 +283,9 @@ pub enum RutabagaError {
     /// Invalid cross domain state
     #[error("invalid cross domain state")]
     InvalidCrossDomainState,
+    /// Invalid cross domain write length for item type
+    #[error("invalid cross domain write length for item type")]
+    InvalidCrossDomainWriteLength,
     /// Invalid gralloc backend.
     #[error("invalid gralloc backend")]
     InvalidGrallocBackend,


### PR DESCRIPTION
This is already done by muvm's current PipeWire proxy like this, we've just been lucky that guest-to-host signaling is very rare in PipeWire (only seems to be used when the profiler is enabled).

---

Oops, this is the real answer to 'Do we need `add`…?' — only just noticed while reading the bridge code that it [already can do this](https://github.com/AsahiLinux/muvm/blob/56c6abc1e5919ac6d391ad7c6df40a1b8adc3e44/crates/muvm/src/guest/bridge/pipewire.rs#L421-L438), it's just not common in practice.