### PR TITLE
rutabaga_gfx: ffi: support cargo-c to build as a C-shared library

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2.93"
 log = "0.4"
 
 [features]
+capi = []
 gbm = ["rutabaga_gfx/gbm"]
 gfxstream = ["rutabaga_gfx/gfxstream"]
 vulkano = ["rutabaga_gfx/vulkano"]


### PR DESCRIPTION
A command such as 'cargo cinstall --release --prefix=<path>' will generate not only shared library but also *.pc file which is about pkgconfig.

This change supports the command to generate them.