### PR TITLE
subprojects: enable serde_json fast arithmetic on riscv

### DIFF
--- a/subprojects/packagefiles/serde_json-1-rs/meson.build
+++ b/subprojects/packagefiles/serde_json-1-rs/meson.build
@@ -18,9 +18,9 @@ memchr = subproject('memchr-2-rs').get_variable('lib')
 
 rust_args = ['--cfg=feature="default"', '--cfg=feature="std"']
 
-if host_machine.cpu_family() == 'x86_64' or host_machine.cpu_family() == 'aarch64'
+if host_machine.cpu_family() == 'x86_64' or host_machine.cpu_family() == 'aarch64' or host_machine.cpu_family() == 'riscv64'
     rust_args += '--cfg=fast_arithmetic="64"'
-elif host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'arm'
+elif host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'arm' or host_machine.cpu_family() == 'riscv32'
     rust_args += '--cfg=fast_arithmetic="32"'
 endif
 


### PR DESCRIPTION
serde_json uses build.rs to emit fast_arithmetic="64" for 64-bit targets. The Meson packagefile mirrors that Cargo build script output manually because this build path invokes rustc directly. Its current list only covers x86_64 and aarch64, so a riscv64 native build reaches src/read.rs without either fast_arithmetic cfg and fails with the Chunk alias undefined.

Add riscv64 to the 64-bit fast_arithmetic branch. This matches serde_json's own build script behavior for riscv64/32 and keeps the Meson rustc arguments complete for native riscv builds.