### PR TITLE
meson2hermetic + rutabaga-release-1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.1.80](https://github.com/magma-gpu/rutabaga_gfx/tree/v0.1.80)
+
+### API and dependencies
+
+- `rutabaga_gfx`
+  - Various Mesa3D crates deprecated; consolidated into `magma-gpu` crate as part of
+    [upstream refactor](https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15548)
+  - `RutabagaMesaHandle` --> `RutabagaMagmaHandle`
+
+### Development
+
+- Major changes to cross-domain to support X11/Pipewire channel types
+- meson2hermetic TOML files added
+
 ## [v0.1.76](https://github.com/magma-gpu/rutabaga_gfx/tree/v0.1.76)
 
 ### API and dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "rutabaga_gfx"
-version = "0.1.76"
+version = "0.1.80"
 authors = ["Magma GPU project"]
 edition = "2021"
 description = "Cross-platform, open-source, Rust-based graphics paravirtualization"
@@ -33,7 +33,7 @@ serde_json = "1"
 thiserror = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 zerocopy = { version = "0.8.13", features = ["derive"] }
-magma-gpu = { path = "third_party/mesa3d/src/virtio/magma-gpu-rs/lib", version = "0.1.76-alpha.0" }
+magma-gpu = { path = "third_party/mesa3d/src/virtio/magma-gpu-rs/lib", version = "0.1.80" }
 
 # To build latest Vulkano, change version to git = "https://github.com/vulkano-rs/vulkano.git"
 vulkano = { version = "0.33.0", optional = true }

--- a/build/dependencies.toml
+++ b/build/dependencies.toml
@@ -1,0 +1,58 @@
+# Copyright 2026 The Magma GPU Project
+# SPDX-License-Identifier: MIT
+[shared_libraries]
+android-base = [
+    { target_name = "libbase" }
+]
+"libc++" = [
+    { target_name = "libc++" }
+]
+
+[static_libraries]
+gfxstream_backend = [
+    { target_name = "libgfxstream_backend" }
+]
+
+[rust_libraries]
+cfg-if = [
+    { target_name = "libcfg_if" }
+]
+bitflags = [
+    { target_name = "libbitflags" }
+]
+errno = [
+    { target_name = "liberrno" }
+]
+rust-nativewindow = [
+    { target_name = "libnativewindow_rs" }
+]
+remain = [
+    { target_name = "libremain", proc_macro = true }
+]
+rustix = [
+    { target_name = "librustix" }
+]
+rust-clap = [
+    { target_name = "libclap" }
+]
+rust-libc = [
+    { target_name = "liblibc" }
+]
+rust-log = [
+    { target_name = "liblog_rust" }
+]
+thiserror = [
+    { target_name = "libthiserror" }
+]
+rust-serde = [
+    { target_name = "libserde" }
+]
+rust-serde-json = [
+    { target_name = "libserde_json" }
+]
+zerocopy = [
+    { target_name = "libzerocopy" }
+]
+zerocopy-derive = [
+    { target_name = "libzerocopy_derive", proc_macro = true }
+]

--- a/build/platforms.toml
+++ b/build/platforms.toml
@@ -1,0 +1,75 @@
+# Copyright 2026 The Magma GPU Project
+# SPDX-License-Identifier: MIT
+
+[[platform]]
+name = "android_arm64"
+
+[platform.machine_info]
+cpu_family = "aarch64"
+cpu = "aarch64"
+system = "android"
+endian = "little"
+
+[platform.rust]
+compiler_id = "rustc"
+linker_id = "ld.lld"
+version = "1.90.0"
+
+[[platform]]
+name = "android_x86"
+
+[platform.machine_info]
+cpu_family = "x86"
+cpu = "i686"
+system = "android"
+endian = "little"
+
+[platform.rust]
+compiler_id = "rustc"
+linker_id = "ld.lld"
+version = "1.90.0"
+
+[[platform]]
+name = "android_x86_64"
+
+[platform.machine_info]
+cpu_family = "x86_64"
+cpu = "x86_64"
+system = "android"
+endian = "little"
+
+[platform.rust]
+compiler_id = "rustc"
+linker_id = "ld.lld"
+version = "1.90.0"
+
+[[platform]]
+name = "linux_glibc_x86_64"
+
+[platform.machine_info]
+cpu_family = "x86_64"
+cpu = "x86_64"
+system = "linux"
+endian = "little"
+
+[[platform]]
+name = "linux_musl_x86_64"
+
+[platform.machine_info]
+cpu_family = "x86_64"
+cpu = "x86_64"
+system = "linux"
+endian = "little"
+
+[platform.rust]
+compiler_id = "rustc"
+linker_id = "ld.lld"
+version = "1.90.0"
+
+[[platform]]
+name = "linux_musl_aarch64"
+
+[platform.rust]
+compiler_id = "rustc"
+linker_id = "ld.lld"
+version = "1.90.0"

--- a/build/rutabaga_gfx.toml
+++ b/build/rutabaga_gfx.toml
@@ -1,0 +1,39 @@
+# Copyright 2026 The Magma GPU Project
+# SPDX-License-Identifier: MIT
+[project]
+project_name = 'rutabaga_gfx'
+project_path = 'external/rust/rutabaga_gfx'
+build_system = 'soong'
+
+[copyright]
+license_name = "external_rutabaga_gfx_license"
+licenses = ["BSD", "MIT"]
+license_texts = ["LICENSE"]
+
+[target_renames]
+magma_gpu = "magma_gpu_rutabaga"
+rust_global_args = "rust_global_args_rutabaga"
+
+[soong_properties]
+partition_type = 'vendor_available'
+apex_available = 'com.android.virt'
+compile_multilib = '64'
+
+[[config]]
+config_name = 'aosp_rutabaga_gfx'
+
+[config.platforms]
+host_platforms = [
+    "android_arm64",
+    "android_x86_64",
+    "linux_glibc_x86_64",
+    "linux_musl_x86_64",
+]
+build_platforms = [
+    "linux_glibc_x86_64",
+    "linux_musl_x86_64",
+]
+
+[config.static_options]
+features = "gfxstream"
+kumquat = true

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rutabaga_gfx_ffi"
-version = "0.1.76"
+version = "0.1.80"
 authors = ["Magma GPU project"]
 edition = "2021"
 description = "FFI interface to rutabaga_gfx"
@@ -13,7 +13,7 @@ name = "rutabaga_gfx_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-rutabaga_gfx = { path = "../", version = "0.1.61"}
+rutabaga_gfx = { path = "../", version = "0.1.80"}
 libc = "0.2.93"
 log = "0.4"
 

--- a/kumquat/meson.build
+++ b/kumquat/meson.build
@@ -1,7 +1,7 @@
 # Copyright 2025 Magma-GPU
 # SPDX-License-Identifier: MIT
 
-dep_clap = dependency('clap-4-rs',
+dep_clap = dependency('rust-clap',
   version: '>= 4.1.8',
   fallback: ['clap-4-rs', 'dep_clap'],
   required: true,

--- a/kumquat/server/Cargo.toml
+++ b/kumquat/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kumquat_virtio"
-version = "0.1.76"
+version = "0.1.80"
 authors = ["Magma GPU project"]
 edition = "2021"
 description = "A Rust server designed for virtio-multimedia use cases"
@@ -16,8 +16,8 @@ path = "src/main.rs"
 gfxstream = ["rutabaga_gfx/gfxstream"]
 
 [dependencies]
-magma-gpu = { path = "../../third_party/mesa3d/src/virtio/magma-gpu-rs/lib", version = "0.1.76-alpha.0" }
-rutabaga_gfx = { path = "../../", version = "0.1.76"}
+magma-gpu = { path = "../../third_party/mesa3d/src/virtio/magma-gpu-rs/lib", version = "0.1.80" }
+rutabaga_gfx = { path = "../../", version = "0.1.80"}
 zerocopy = { version = "0.8.13", features = ["derive"] }
 log = "0.4"
 remain = "0.2"

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   'rutabaga_gfx',
   ['rust', 'c'],
   license : 'BSD-3-Clause AND MIT',
-  version: '0.1.76',
+  version: '0.1.80',
   meson_version: '>=1.3.0',
   default_options : [
     'rust_std=2021',

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ if with_gfxstream
   dep_gfxstream = dependency('gfxstream_backend', version: '>= 0.1.2')
   rutabaga_args += ['--cfg', 'feature="gfxstream"']
   dep_rutabaga_gfx += dep_gfxstream
+  dep_rutabaga_gfx += dependency('libc++', required: false)
 endif
 
 if with_virgl_renderer

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,25 +1,25 @@
 # Copyright 2025 Magma-GPU project
 # SPDX-License-Identifier: MIT
 
-dep_libc = dependency('libc-0.2-rs',
+dep_libc = dependency('rust-libc',
   version: '>= 0.2.153',
   fallback: ['libc-0.2-rs', 'dep_libc'],
   required: true,
 )
 
-dep_log = dependency('log-0.4-rs',
+dep_log = dependency('rust-log',
   version: '>= 0.4',
   fallback: ['log-0.4-rs', 'dep_log'],
   required: true,
 )
 
-dep_serde = dependency('serde-1-rs',
+dep_serde = dependency('rust-serde',
   version: '>= 1',
   fallback: ['serde-1-rs', 'dep_serde'],
   required: true,
 )
 
-dep_serde_json = dependency('serde_json-1-rs',
+dep_serde_json = dependency('rust-serde-json',
   version: '>= 1',
   fallback: ['serde_json-1-rs', 'dep_serde_json'],
   required: true,
@@ -32,6 +32,10 @@ dep_rutabaga_gfx += [
   dep_serde_json,
   dep_serde,
 ]
+
+if host_machine.system() == 'android'
+  dep_rutabaga_gfx += dependency('rust-nativewindow')
+endif
 
 librutabaga_gfx = static_library(
   'rutabaga_gfx',

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -1121,12 +1121,6 @@ impl Rutabaga {
             .ok_or(MagmaGpuError::WithContext("no 3d info available").into())
     }
 
-    /// Returns true if the resource is mappable by the guest CPU.
-    #[deprecated(since = "0.1.76", note = "ChromeOS specific API, do not use")]
-    pub fn guest_cpu_mappable(&self, _resource_id: u32) -> RutabagaResult<bool> {
-        unimplemented!();
-    }
-
     /// Exports a blob resource.  See virtio-gpu spec for blob flag use flags.
     pub fn export_blob(&mut self, resource_id: u32) -> RutabagaResult<RutabagaHandle> {
         let resource = self

--- a/third_party/mesa3d/src/magma/Cargo.toml
+++ b/third_party/mesa3d/src/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma_gpu_magma"
-version = "0.1.76"
+version = "0.1.80"
 authors = ["Mesa3D Authors"]
 edition = "2021"
 description = "This is a GPU system call abstraction crate"
@@ -11,7 +11,7 @@ name = "magma_gpu_magma"
 path = "lib.rs"
 
 [dependencies]
-magma-gpu = {path = "../virtio/magma-gpu-rs/lib", version = "0.1.76-alpha.0"}
+magma-gpu = {path = "../virtio/magma-gpu-rs/lib", version = "0.1.80"}
 cfg-if = "1.0.0"
 libc = "0.2.116"
 remain = "0.2"

--- a/third_party/mesa3d/src/magma/meson.build
+++ b/third_party/mesa3d/src/magma/meson.build
@@ -4,142 +4,56 @@
 magma_generated_libs = []
 
 dep_windows_sys = null_dep
+dep_libc_rs = null_dep
 if host_machine.system() == 'linux' or host_machine.system() == 'android'
-  drm_bindgen = rust.bindgen(
-    input : drm_h,
-    output : 'magma_gpu_magma_drm_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
-      '--with-derive-default',
-      '--allowlist-var', 'DRM_.+',
-      '--allowlist-var', 'drm_.+',
-      '--allowlist-type', 'drm_.+',
-      '--no-prepend-enum-name',
-      '--no-doc-comments',
-      '--no-layout-tests'
-    ],
-  )
+  bindgen_configs = [
+    ['drm',     drm_h,        ['DRM_.+', 'drm_.+'],               ['drm_.+']],
+    ['amdgpu',  amdgpu_drm_h, ['DRM_AMDGPU_.+', 'AMDGPU_.+'],     ['drm_amdgpu_.+']],
+    ['msm',     msm_drm_h,    ['DRM_MSM_.+', 'MSM_.+'],           ['drm_msm_.+']],
+    ['virtgpu', virtgpu_drm_h,['DRM_VIRTGPU_.+', 'VIRTGPU_.+'],   ['drm_virtgpu_.+']],
+    ['i915',    i915_drm_h,   ['DRM_I915_.+', 'I915_.+'],         ['drm_i915_.+']],
+    ['xe',      xe_drm_h,     ['DRM_XE_.+', 'XE_.+'],             ['drm_xe_.+']]
+  ]
 
-  amdgpu_bindgen = rust.bindgen(
-    input : amdgpu_drm_h,
-    output : 'magma_gpu_magma_amdgpu_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
-      '--with-derive-default',
-      '--allowlist-var', 'DRM_AMDGPU_.+',
-      '--allowlist-var', 'AMDGPU_.+',
-      '--allowlist-type', 'drm_amdgpu_.+',
-      '--no-prepend-enum-name',
-      '--no-doc-comments',
-      '--no-layout-tests'
-    ],
-  )
+  foreach config : bindgen_configs
+    name = config[0]
+    header = config[1]
 
-  msm_bindgen = rust.bindgen(
-    input : msm_drm_h,
-    output : 'magma_gpu_magma_msm_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
+    bindgen_args = [
       '--with-derive-default',
-      '--allowlist-var', 'DRM_MSM_.+',
-      '--allowlist-var', 'MSM_.+',
-      '--allowlist-type', 'drm_msm_.+',
-      '--no-prepend-enum-name',
-      '--no-doc-comments',
-      '--no-layout-tests'
-    ],
-  )
-
-  virtgpu_bindgen = rust.bindgen(
-    input : virtgpu_drm_h,
-    output : 'magma_gpu_magma_virtgpu_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
-      '--with-derive-default',
-      '--allowlist-var', 'DRM_VIRTGPU_.+',
-      '--allowlist-var', 'VIRTGPU_.+',
-      '--allowlist-type', 'drm_virtgpu_.+',
       '--no-prepend-enum-name',
       '--no-doc-comments',
       '--no-layout-tests'
     ]
-  )
 
-  xe_bindgen = rust.bindgen(
-    input : xe_drm_h,
-    output : 'magma_gpu_magma_xe_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
-      '--with-derive-default',
-      '--allowlist-var', 'DRM_XE.+',
-      '--allowlist-var', 'XE_.+',
-      '--allowlist-type', 'drm_xe_.+',
-      '--no-prepend-enum-name',
-      '--no-doc-comments',
-      '--no-layout-tests'
-    ],
-  )
+    foreach var_pattern : config[2]
+      bindgen_args += ['--allowlist-var', var_pattern]
+    endforeach
 
-  i915_bindgen = rust.bindgen(
-    input : i915_drm_h,
-    output : 'magma_gpu_magma_i915_bindgen.rs',
-    include_directories : [inc_include],
-    args : [
-      '--with-derive-default',
-      '--allowlist-var', 'DRM_I915.+',
-      '--allowlist-var', 'I915_.+',
-      '--allowlist-type', 'drm_i915_.+',
-      '--no-prepend-enum-name',
-      '--no-doc-comments',
-      '--no-layout-tests'
-    ],
-  )
+    foreach type_pattern : config[3]
+      bindgen_args += ['--allowlist-type', type_pattern]
+    endforeach
 
-  drm_bindgen_gen = static_library(
-    'magma_gpu_magma_drm_bindgen',
-    drm_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
+    generated_rs = rust.bindgen(
+      input : header,
+      output : 'magma_gpu_magma_' + name + '_bindgen.rs',
+      include_directories : [inc_include],
+      args : bindgen_args,
+    )
 
-  amdgpu_bindgen_gen = static_library(
-    'magma_gpu_magma_amdgpu_bindgen',
-    amdgpu_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
+    magma_generated_libs += static_library(
+      'magma_gpu_magma_' + name + '_bindgen',
+      generated_rs,
+      gnu_symbol_visibility : 'hidden',
+      rust_abi : 'rust',
+    )
 
-  msm_bindgen_gen = static_library(
-    'magma_gpu_magma_msm_bindgen',
-    msm_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
-
-  virtgpu_bindgen_gen = static_library(
-    'magma_gpu_magma_virtgpu_bindgen',
-    virtgpu_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
-
-  i915_bindgen_gen = static_library(
-    'magma_gpu_magma_i915_bindgen',
-    i915_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
-
-  xe_bindgen_gen = static_library(
-    'magma_gpu_magma_xe_bindgen',
-    xe_bindgen,
-    gnu_symbol_visibility : 'hidden',
-    rust_abi : 'rust',
-  )
-
-  magma_generated_libs += [drm_bindgen_gen, amdgpu_bindgen_gen,
-                           msm_bindgen_gen, virtgpu_bindgen_gen,
-                           i915_bindgen_gen, xe_bindgen_gen]
+    dep_libc_rs = dependency('rust-libc',
+      version: '>= 0.2.185',
+      fallback: ['libc-0.2-rs', 'dep_libc'],
+      required: true,
+    )
+  endforeach
 elif host_machine.system() == 'windows'
   dep_windows_sys = dependency('windows-sys-rs',
     version: '>= 0.61.1',
@@ -158,5 +72,5 @@ libmesa_magma = static_library(
   rust_abi : 'rust',
   rust_args: magma_args,
   link_with: [magma_generated_libs, libmagma_gpu_rs],
-  dependencies: [dep_magma_gpu_rs, dep_windows_sys]
+  dependencies: [dep_magma_gpu_rs, dep_windows_sys, dep_libc_rs]
 )

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/Cargo.toml
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma-gpu"
-version = "0.1.76-alpha.0"
+version = "0.1.80"
 authors = ["Magma GPU project"]
 edition = "2021"
 description = "An experimental crate to enable microkernel-gpu"

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/meson.build
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/meson.build
@@ -34,7 +34,7 @@ dep_zerocopy = dependency('zerocopy',
 dep_magma_gpu_rs = [dep_cfg_if, dep_thiserror, dep_remain, dep_zerocopy,
                  dep_log]
 
-supported_systems = ['linux', 'windows', 'darwin', 'macos']
+supported_systems = ['android', 'linux', 'windows', 'darwin', 'macos']
 supported_host_machine = host_machine.system() in supported_systems
 
 if supported_host_machine

--- a/third_party/meson.build
+++ b/third_party/meson.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 subdir('mesa3d/src/virtio/magma-gpu-rs/lib')
-if host_machine.system() == 'linux' or host_machine.system() == 'windows'
+if host_machine.system() == 'linux' or host_machine.system() == 'android' or host_machine.system() == 'windows'
   subdir('mesa3d/src/magma/headers')
   subdir('mesa3d/src/magma')
 endif


### PR DESCRIPTION
This adds support for meson2hermetic, and cuts Rutabaga release 0.1.80.  There were some slight API changes, but's it's been tested with crosvm.