### PR TITLE
rutabaga: Fix map_placed implementation for fixed mappings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn gbm() -> PkgConfigResult<()> {
 
 fn virglrenderer() -> PkgConfigResult<()> {
     let lib = pkg_config::Config::new()
-        .atleast_version("1.0.0")
+        .atleast_version("1.3.0")
         .probe("virglrenderer")?;
     if lib.defines.contains_key("VIRGL_RENDERER_UNSTABLE_APIS") {
         println!("cargo:rustc-cfg=virgl_renderer_unstable");

--- a/src/generated/virgl_renderer_bindings.rs
+++ b/src/generated/virgl_renderer_bindings.rs
@@ -437,7 +437,6 @@ extern "C" {
         out_size: *mut u64,
     ) -> ::std::os::raw::c_int;
 }
-#[cfg(virgl_renderer_unstable)]
 extern "C" {
     pub fn virgl_renderer_resource_map_fixed(
         res_handle: u32,

--- a/src/rutabaga_core.rs
+++ b/src/rutabaga_core.rs
@@ -317,9 +317,7 @@ pub trait RutabagaComponent {
         Err(MagmaGpuError::Unsupported.into())
     }
 
-    /// Implementations must map the blob resource on success. If addr is Some, the resource
-    /// should be mapped at the specified address. Otherwise, the implementation may choose
-    /// the address.
+    /// Implementations must map the blob resource at `placed_addr` on success.
     fn map_placed(&self, _resource_id: u32, _placed_addr: u64) -> RutabagaResult<()> {
         Err(MagmaGpuError::Unsupported.into())
     }

--- a/src/virgl_renderer.rs
+++ b/src/virgl_renderer.rs
@@ -886,27 +886,22 @@ impl RutabagaComponent for VirglRenderer {
         })
     }
 
-    fn map_placed(&self, _resource_id: u32, _addr: u64) -> RutabagaResult<()> {
-        #[cfg(virgl_renderer_unstable)]
-        {
-            if let Some(addr) = _addr {
-                // SAFETY:
-                // Safe because virglrenderer is initialized and addr is a valid pointer provided
-                // by the caller.
-                let ret = unsafe {
-                    virgl_renderer_resource_map_fixed(_resource_id, addr as *mut libc::c_void)
-                };
-                if ret != 0 {
-                    return Err(RutabagaError::MappingFailed(ret));
-                }
-                Ok(())
-            } else {
-                // virgl_renderer_resource_map_fixed requires a fixed address
-                Err(MagmaGpuError::Unsupported.into())
+    fn map_placed(&self, resource_id: u32, addr: u64) -> RutabagaResult<()> {
+        if addr != 0 {
+            // SAFETY:
+            // Safe because virglrenderer is initialized and addr is a valid pointer provided
+            // by the caller.
+            let ret = unsafe {
+                virgl_renderer_resource_map_fixed(resource_id, addr as *mut libc::c_void)
+            };
+            if ret != 0 {
+                return Err(RutabagaError::MappingFailed(ret));
             }
+            Ok(())
+        } else {
+            // virgl_renderer_resource_map_fixed requires a fixed address
+            Err(MagmaGpuError::Unsupported.into())
         }
-        #[cfg(not(virgl_renderer_unstable))]
-        Err(MagmaGpuError::Unsupported.into())
     }
 
     fn map(&self, resource_id: u32) -> RutabagaResult<MesaMapping> {


### PR DESCRIPTION
map_placed takes a fixed address as a u64, but the virgl_renderer implementation still treated the parameter as an Option<u64>:
```
if let Some(addr) = _addr
```
This causes a compilation failure with virgl_renderer_unstable enabled:
```
error[E0308]: mismatched types
expected `u64`, found `Option<_>`
```
    
cc @slp @zzyiwei 