### PR TITLE
Fixes ported from libkrun's downstream rutabaga_gfx

### DIFF
--- a/kumquat/server/src/kumquat_gpu/mod.rs
+++ b/kumquat/server/src/kumquat_gpu/mod.rs
@@ -87,7 +87,7 @@ pub fn create_fence_handler(fence_state: FenceState) -> RutabagaFenceHandler {
         let mut state = fence_state.lock().unwrap();
         match state.pending_fences.entry(completed_fence.fence_id) {
             Entry::Occupied(o) => {
-                let (_, mut event) = o.remove_entry();
+                let (_, event) = o.remove_entry();
                 event.signal().unwrap();
             }
             Entry::Vacant(_) => {
@@ -335,7 +335,7 @@ impl KumquatGpuConnection {
                         .rutabaga
                         .transfer_write(cmd.ctx_id, resource_id, transfer, None)?;
 
-                    let mut event: Event = emulated_fence.try_into()?;
+                    let event: Event = emulated_fence.try_into()?;
                     event.signal()?;
                 }
                 KumquatGpuProtocol::TransferFromHost3d(cmd, emulated_fence) => {
@@ -358,7 +358,7 @@ impl KumquatGpuConnection {
                         .rutabaga
                         .transfer_read(cmd.ctx_id, resource_id, transfer, None)?;
 
-                    let mut event: Event = emulated_fence.try_into()?;
+                    let event: Event = emulated_fence.try_into()?;
                     event.signal()?;
                 }
                 KumquatGpuProtocol::CmdSubmit3d(cmd, mut cmd_buf, fence_ids) => {

--- a/src/cross_domain/atomic_memory_sentinel_manager.rs
+++ b/src/cross_domain/atomic_memory_sentinel_manager.rs
@@ -51,7 +51,7 @@ impl AtomicMemorySentinelThread {
         }
     }
 
-    fn run(mut self) {
+    fn run(self) {
         // The goal of this code is to ensure that the other side observes at least
         // the latest wake event along with the value that the futex had when that
         // wake event was signaled.

--- a/src/cross_domain/common.rs
+++ b/src/cross_domain/common.rs
@@ -57,7 +57,7 @@ pub enum CrossDomainJob {
 pub enum RingWrite<'a, T> {
     Write(T, Option<&'a [u8]>),
     WriteFromPipe(CrossDomainReadWrite, &'a mut ReadPipe, bool),
-    WriteFromEvent(CrossDomainReadWrite, &'a mut Event, bool),
+    WriteFromEvent(CrossDomainReadWrite, &'a Event, bool),
 }
 
 pub type CrossDomainJobs = Mutex<Option<VecDeque<CrossDomainJob>>>;
@@ -192,7 +192,7 @@ impl CrossDomainState {
                     .map_err(MagmaGpuError::TryFromIntError)?;
                 cmd_slice.copy_from_slice(cmd_read.as_bytes());
             }
-            RingWrite::WriteFromEvent(mut cmd_read, ref mut event, readable) => {
+            RingWrite::WriteFromEvent(mut cmd_read, event, readable) => {
                 if slice.len() < size_of::<CrossDomainReadWrite>() {
                     return Err(RutabagaError::InvalidIovec);
                 }

--- a/src/cross_domain/common.rs
+++ b/src/cross_domain/common.rs
@@ -41,7 +41,7 @@ pub enum CrossDomainItem {
     Blob(MagmaGpuHandle),
     WaylandReadPipe(ReadPipe),
     WaylandWritePipe(WritePipe),
-    Event(Event),
+    Event(Arc<Event>),
     RegularFile(OwnedDescriptor),
     Socket(OwnedDescriptor),
 }

--- a/src/cross_domain/context.rs
+++ b/src/cross_domain/context.rs
@@ -465,20 +465,48 @@ impl CrossDomainContext {
     }
 
     fn write(&self, cmd_write: &CrossDomainReadWrite, opaque_data: &[u8]) -> RutabagaResult<()> {
-        let mut items = self.item_state.lock().unwrap();
+        let len: usize = cmd_write
+            .opaque_data_size
+            .try_into()
+            .map_err(MagmaGpuError::TryFromIntError)?;
 
-        // Most of the time, hang-up and writing will be paired.  In lieu of this, remove the
-        // item rather than getting a reference.  In case of an error, there's not much to do
-        // besides reporting it.
+        // For Event items (e.g. PipeWire per-period eventfd wakeups), clone
+        // the Arc under the lock and perform the actual write lock-free.
+        // This avoids serializing every CMD_WRITE behind unrelated
+        // item_state operations (such as add_item from process_receive),
+        // which can exceed audio period budgets under stream-create churn.
+        {
+            let items = self.item_state.lock().unwrap();
+            let item = items
+                .table
+                .get(&cmd_write.identifier)
+                .ok_or(RutabagaError::InvalidCrossDomainItemId)?;
+            if let CrossDomainItem::Event(event) = item {
+                let event = Arc::clone(event);
+
+                let Ok(bytes) = <[u8; 8]>::try_from(opaque_data) else {
+                    return Err(RutabagaError::InvalidCrossDomainWriteLength);
+                };
+
+                drop(items);
+                event.add(u64::from_le_bytes(bytes))?;
+
+                if cmd_write.hang_up != 0 {
+                    let mut items = self.item_state.lock().unwrap();
+                    items.table.remove(&cmd_write.identifier);
+                }
+
+                return Ok(());
+            }
+        }
+
+        // For non-Event items, use the original remove-and-reinsert pattern.
+        let mut items = self.item_state.lock().unwrap();
         let item = items
             .table
             .remove(&cmd_write.identifier)
             .ok_or(RutabagaError::InvalidCrossDomainItemId)?;
 
-        let len: usize = cmd_write
-            .opaque_data_size
-            .try_into()
-            .map_err(MagmaGpuError::TryFromIntError)?;
         match item {
             CrossDomainItem::WaylandWritePipe(write_pipe) => {
                 if len != 0 {
@@ -490,21 +518,6 @@ impl CrossDomainContext {
                         cmd_write.identifier,
                         CrossDomainItem::WaylandWritePipe(write_pipe),
                     );
-                }
-
-                Ok(())
-            }
-            CrossDomainItem::Event(mut event) => {
-                let Ok(bytes) = <[u8; 8]>::try_from(opaque_data) else {
-                    return Err(RutabagaError::InvalidCrossDomainWriteLength);
-                };
-
-                event.add(u64::from_le_bytes(bytes))?;
-
-                if cmd_write.hang_up == 0 {
-                    items
-                        .table
-                        .insert(cmd_write.identifier, CrossDomainItem::Event(event));
                 }
 
                 Ok(())

--- a/src/cross_domain/context.rs
+++ b/src/cross_domain/context.rs
@@ -349,7 +349,7 @@ impl CrossDomainContext {
             }
         }
 
-        if let (Some(state), Some(ref mut resample_evt)) = (&self.state, &mut self.resample_evt) {
+        if let (Some(state), Some(ref resample_evt)) = (&self.state, &self.resample_evt) {
             state.send_msg(opaque_data, &descriptors)?;
 
             if let Some(read_pipe_id) = read_pipe_id_opt {
@@ -408,7 +408,7 @@ impl CrossDomainContext {
                     .as_ref()
                     .unwrap()
                     .add_job(CrossDomainJob::AddReadEvent(cmd_event_new.id));
-                self.resample_evt.as_mut().unwrap().signal()?;
+                self.resample_evt.as_ref().unwrap().signal()?;
                 Ok(())
             } else {
                 Err(RutabagaError::InvalidCrossDomainItemType)
@@ -780,7 +780,7 @@ impl Drop for CrossDomainContext {
             state.add_job(CrossDomainJob::Finish);
         }
 
-        if let Some(mut kill_evt) = self.kill_evt.take() {
+        if let Some(kill_evt) = self.kill_evt.take() {
             // Log the error, but still try to join the worker thread
             match kill_evt.signal() {
                 Ok(_) => (),

--- a/src/cross_domain/worker.rs
+++ b/src/cross_domain/worker.rs
@@ -71,7 +71,7 @@ impl CrossDomainWorker {
     fn handle_fence(
         &mut self,
         fence: RutabagaFence,
-        thread_resample_evt: &mut Event,
+        thread_resample_evt: &Event,
         receive_buf: &mut [u8],
     ) -> RutabagaResult<()> {
         let events = self.wait_ctx.wait(WaitTimeout::NoTimeout)?;
@@ -176,7 +176,7 @@ impl CrossDomainWorker {
                                 self.wait_ctx.delete(readpipe.as_borrowed_descriptor())?;
                             }
                         }
-                        CrossDomainItem::Event(ref mut evt) => {
+                        CrossDomainItem::Event(ref evt) => {
                             let ring_write =
                                 RingWrite::WriteFromEvent(cmd_read, evt, event.readable);
                             bytes_read = self.state.write_to_ring::<CrossDomainReadWrite>(
@@ -283,7 +283,7 @@ impl CrossDomainWorker {
     pub fn run(
         &mut self,
         thread_kill_evt: Event,
-        mut thread_resample_evt: Event,
+        thread_resample_evt: Event,
     ) -> RutabagaResult<()> {
         self.wait_ctx.add(
             CROSS_DOMAIN_RESAMPLE_ID,
@@ -298,7 +298,7 @@ impl CrossDomainWorker {
         while let Some(job) = self.state.wait_for_job() {
             match job {
                 CrossDomainJob::HandleFence(fence) => {
-                    match self.handle_fence(fence, &mut thread_resample_evt, &mut receive_buf) {
+                    match self.handle_fence(fence, &thread_resample_evt, &mut receive_buf) {
                         Ok(()) => (),
                         Err(e) => {
                             error!("Worker halting due to: {e}");

--- a/src/cross_domain/worker.rs
+++ b/src/cross_domain/worker.rs
@@ -239,7 +239,8 @@ impl CrossDomainWorker {
                             os_handle: file,
                             handle_type: MAGMA_GPU_HANDLE_TYPE_SIGNAL_EVENT_FD,
                         })?;
-                        *identifier = add_item(&self.item_state, CrossDomainItem::Event(event));
+                        *identifier =
+                            add_item(&self.item_state, CrossDomainItem::Event(Arc::new(event)));
                     }
                     DescriptorType::Memory(size, handle_type) => {
                         *identifier_type = CROSS_DOMAIN_ID_TYPE_VIRTGPU_BLOB;

--- a/src/rutabaga_gralloc/formats.rs
+++ b/src/rutabaga_gralloc/formats.rs
@@ -23,26 +23,26 @@ use crate::rutabaga_utils::RutabagaResult;
  * used by guest userspace (i.e, DRM_FORMAT_RGB332) are left out for simplicity.
  */
 
-pub const DRM_FORMAT_R8: [u8; 4] = [b'R', b'8', b' ', b' '];
+pub const DRM_FORMAT_R8: [u8; 4] = *b"R8  ";
 
-pub const DRM_FORMAT_RGB565: [u8; 4] = [b'R', b'G', b'1', b'6'];
-pub const DRM_FORMAT_BGR888: [u8; 4] = [b'B', b'G', b'2', b'4'];
+pub const DRM_FORMAT_RGB565: [u8; 4] = *b"RG16";
+pub const DRM_FORMAT_BGR888: [u8; 4] = *b"BG24";
 
-pub const DRM_FORMAT_XRGB8888: [u8; 4] = [b'X', b'R', b'2', b'4'];
-pub const DRM_FORMAT_XBGR8888: [u8; 4] = [b'X', b'B', b'2', b'4'];
+pub const DRM_FORMAT_XRGB8888: [u8; 4] = *b"XR24";
+pub const DRM_FORMAT_XBGR8888: [u8; 4] = *b"XB24";
 
-pub const DRM_FORMAT_ARGB8888: [u8; 4] = [b'A', b'R', b'2', b'4'];
-pub const DRM_FORMAT_ABGR8888: [u8; 4] = [b'A', b'B', b'2', b'4'];
+pub const DRM_FORMAT_ARGB8888: [u8; 4] = *b"AR24";
+pub const DRM_FORMAT_ABGR8888: [u8; 4] = *b"AB24";
 
-pub const DRM_FORMAT_XRGB2101010: [u8; 4] = [b'X', b'R', b'3', b'0'];
-pub const DRM_FORMAT_XBGR2101010: [u8; 4] = [b'X', b'B', b'3', b'0'];
-pub const DRM_FORMAT_ARGB2101010: [u8; 4] = [b'A', b'R', b'3', b'0'];
-pub const DRM_FORMAT_ABGR2101010: [u8; 4] = [b'A', b'B', b'3', b'0'];
+pub const DRM_FORMAT_XRGB2101010: [u8; 4] = *b"XR30";
+pub const DRM_FORMAT_XBGR2101010: [u8; 4] = *b"XB30";
+pub const DRM_FORMAT_ARGB2101010: [u8; 4] = *b"AR30";
+pub const DRM_FORMAT_ABGR2101010: [u8; 4] = *b"AB30";
 
-pub const DRM_FORMAT_ABGR16161616F: [u8; 4] = [b'A', b'B', b'4', b'H'];
+pub const DRM_FORMAT_ABGR16161616F: [u8; 4] = *b"AB4H";
 
-pub const DRM_FORMAT_NV12: [u8; 4] = [b'N', b'V', b'1', b'2'];
-pub const DRM_FORMAT_YVU420: [u8; 4] = [b'Y', b'V', b'1', b'2'];
+pub const DRM_FORMAT_NV12: [u8; 4] = *b"NV12";
+pub const DRM_FORMAT_YVU420: [u8; 4] = *b"YV12";
 
 /// A [fourcc](https://en.wikipedia.org/wiki/FourCC) format identifier.
 #[derive(Copy, Clone, Eq, PartialEq, Default)]

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/event.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/event.rs
@@ -27,16 +27,16 @@ impl Event {
         })
     }
 
-    pub fn add(&mut self, value: u64) -> MagmaGpuResult<()> {
+    pub fn add(&self, value: u64) -> MagmaGpuResult<()> {
         let _ = write(&self.descriptor, &value.to_le_bytes())?;
         Ok(())
     }
 
-    pub fn signal(&mut self) -> MagmaGpuResult<()> {
+    pub fn signal(&self) -> MagmaGpuResult<()> {
         self.add(1)
     }
 
-    pub fn wait(&mut self) -> MagmaGpuResult<u64> {
+    pub fn wait(&self) -> MagmaGpuResult<u64> {
         let mut buf = [0; 8];
         read(&self.descriptor, &mut buf)?;
         Ok(u64::from_le_bytes(buf))

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/event.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/event.rs
@@ -14,15 +14,15 @@ impl Event {
         Err(Error::Unsupported)
     }
 
-    pub fn add(&mut self, _value: u64) -> MagmaGpuResult<()> {
+    pub fn add(&self, _value: u64) -> MagmaGpuResult<()> {
         Err(Error::Unsupported)
     }
 
-    pub fn signal(&mut self) -> MagmaGpuResult<()> {
+    pub fn signal(&self) -> MagmaGpuResult<()> {
         Err(Error::Unsupported)
     }
 
-    pub fn wait(&mut self) -> MagmaGpuResult<u64> {
+    pub fn wait(&self) -> MagmaGpuResult<u64> {
         Err(Error::Unsupported)
     }
 

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/event.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/event.rs
@@ -14,15 +14,15 @@ impl Event {
         Err(Error::Unsupported)
     }
 
-    pub fn add(&mut self, _value: u64) -> MagmaGpuResult<()> {
+    pub fn add(&self, _value: u64) -> MagmaGpuResult<()> {
         Err(Error::Unsupported)
     }
 
-    pub fn signal(&mut self) -> MagmaGpuResult<()> {
+    pub fn signal(&self) -> MagmaGpuResult<()> {
         Err(Error::Unsupported)
     }
 
-    pub fn wait(&mut self) -> MagmaGpuResult<u64> {
+    pub fn wait(&self) -> MagmaGpuResult<u64> {
         Err(Error::Unsupported)
     }
 

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/virtgpu_kumquat/virtgpu_kumquat_impl.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/virtgpu_kumquat/virtgpu_kumquat_impl.rs
@@ -497,7 +497,7 @@ impl VirtGpuKumquat {
 
         let new_fences: Vec<Handle> = std::mem::take(&mut resource.attached_fences);
         for fence in new_fences {
-            let mut event: Event = fence.try_into()?;
+            let event: Event = fence.try_into()?;
             event.wait()?;
         }
 


### PR DESCRIPTION
Two fixes ported from libkrun's downstream rutabaga_gfx:
1. cross_domain: fix audio glitches by dropping write lock for Event items
2. rutabaga_gfx: fix clippy byte_char_slices in DRM format constants

For 1. the Original fix by Adam Ford against libkrun's vendored rutabaga_gfx, which used `CrossDomainItem::Eventfd` with `write_volatile` and applied the optimization to both `WaylandWritePipe` and `Eventfd`. Adapted here for upstream's `CrossDomainItem::Event` type with `event.try_clone() + event.add()`. The `WaylandWritePipe` path is left unchanged since `WritePipe` doesn't expose `try_clone()`.