### PR TITLE
expose linker paths to rust build

### DIFF
--- a/ffi/meson.build
+++ b/ffi/meson.build
@@ -7,6 +7,7 @@ librutabaga_gfx_ffi = library(
   dependencies: dep_rutabaga_gfx,
   link_with: [librutabaga_gfx, libmagma_gpu_rs],
   rust_abi: 'c',
+  rust_args: dep_link_args,
   install: true,
 )
 

--- a/kumquat/meson.build
+++ b/kumquat/meson.build
@@ -17,5 +17,6 @@ kumquat_exe = executable(
     librutabaga_gfx,
     libmagma_gpu_rs,
   ],
+  rust_args: dep_link_args,
   install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ with_virgl_renderer = features.contains('virgl_renderer')
 
 rutabaga_args = []
 dep_rutabaga_gfx = []
+dep_link_args = []
 
 rust_global_args = [
   '-Aclippy::collapsible_else_if',
@@ -44,12 +45,14 @@ endif
 if with_gfxstream
   dep_gfxstream = dependency('gfxstream_backend', version: '>= 0.1.2')
   rutabaga_args += ['--cfg', 'feature="gfxstream"']
+  dep_link_args += ['-L', dep_gfxstream.get_variable('libdir')]
   dep_rutabaga_gfx += dep_gfxstream
   dep_rutabaga_gfx += dependency('libc++', required: false)
 endif
 
 if with_virgl_renderer
   dep_virgl = dependency('virglrenderer', version: '>= 1.0.0')
+  dep_link_args += ['-L', dep_virgl.get_variable('libdir')]
   rutabaga_args += ['--cfg', 'feature="virgl_renderer"']
   dep_rutabaga_gfx += dep_virgl
 endif


### PR DESCRIPTION
By default the rust compiler will search the standard library paths which is not helpful for cross-build and rootfs builds. As meson already has probed the library details via pkg-config we can pass those details down to the rust step.