### PR TITLE
magma-gpu-rs: linux/tube: use NOSIGNAL flag for sendmsg

### DIFF
--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/tube.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/tube.rs
@@ -113,7 +113,7 @@ impl Tube {
             &self.socket,
             &[IoSlice::new(opaque_data)],
             &mut cmsg_buffer,
-            SendFlags::empty(),
+            SendFlags::NOSIGNAL,
         )?;
 
         Ok(bytes_sent)


### PR DESCRIPTION
[This is to be sent to Mesa.]

If the host server a cross-domain client is talking to closes the socket (e.g. a Wayland compositor encountering a protocol error), the sendmsg() syscall might be interrupted with SIGPIPE, and without a handler in the VMM/vhost process that would result in the process being killed.

Linux provides a convenient NOSIGNAL flag to avoid this, let's use it.