### PR TITLE
rutabaga_gfx: fix hermetic build

### DIFF
--- a/build/dependencies.toml
+++ b/build/dependencies.toml
@@ -10,7 +10,7 @@ android-base = [
 
 [static_libraries]
 gfxstream_backend = [
-    { target_name = "libgfxstream_backend" }
+    { target_name = "libgfxstream_backend", pkgconfig = {'libdir' = ''}}
 ]
 
 [rust_libraries]

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,10 @@ endif
 if with_gfxstream
   dep_gfxstream = dependency('gfxstream_backend', version: '>= 0.1.2')
   rutabaga_args += ['--cfg', 'feature="gfxstream"']
-  dep_link_args += ['-L', dep_gfxstream.get_variable('libdir')]
+  libdir_gfxstream = dep_gfxstream.get_variable('libdir')
+  if libdir_gfxstream != ''
+    dep_link_args += ['-L', libdir_gfxstream]
+  endif
   dep_rutabaga_gfx += dep_gfxstream
   dep_rutabaga_gfx += dependency('libc++', required: false)
 endif


### PR DESCRIPTION
It doesn't make sense to have user-defined link-paths on hermetic build systems. Return the empty string there and make don't emit empty args.

Test: python3 ~/meson/meson.py convert android rutabaga_gfx