### PR TITLE
magma-gpu-rs: hand the descriptors to Tube::send

### DIFF
--- a/src/cross_domain/common.rs
+++ b/src/cross_domain/common.rs
@@ -96,7 +96,7 @@ impl CrossDomainState {
     pub fn send_msg(
         &self,
         opaque_data: &[u8],
-        descriptors: &[OwnedDescriptor],
+        descriptors: Vec<OwnedDescriptor>,
     ) -> RutabagaResult<usize> {
         match self.connection {
             Some(ref connection) => connection

--- a/src/cross_domain/context.rs
+++ b/src/cross_domain/context.rs
@@ -349,7 +349,7 @@ impl CrossDomainContext {
         }
 
         if let (Some(state), Some(ref resample_evt)) = (&self.state, &self.resample_evt) {
-            state.send_msg(opaque_data, &descriptors)?;
+            state.send_msg(opaque_data, descriptors)?;
 
             if let Some(read_pipe_id) = read_pipe_id_opt {
                 state.add_job(CrossDomainJob::AddReadPipe(read_pipe_id));

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/protocols/ipc/kumquat_stream.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/protocols/ipc/kumquat_stream.rs
@@ -42,19 +42,19 @@ impl KumquatStream {
     ) -> Result<()> {
         let mut writer = Writer::new(&mut self.write_buffer);
 
-        let array: &[OwnedDescriptor] = match encode {
+        let array: Vec<OwnedDescriptor> = match encode {
             KumquatGpuProtocolWrite::Cmd(cmd) => {
                 writer.write_obj(cmd)?;
-                &[]
+                Vec::new()
             }
             KumquatGpuProtocolWrite::CmdWithHandle(cmd, handle) => {
                 writer.write_obj(cmd)?;
-                &[handle.os_handle]
+                vec![handle.os_handle]
             }
             KumquatGpuProtocolWrite::CmdWithData(cmd, data) => {
                 writer.write_obj(cmd)?;
                 writer.write_all(&data)?;
-                &[]
+                Vec::new()
             }
         };
 

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/tube.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/tube.rs
@@ -99,7 +99,7 @@ impl Tube {
     pub fn send(
         &self,
         opaque_data: &[u8],
-        descriptors: &[OwnedDescriptor],
+        descriptors: Vec<OwnedDescriptor>,
     ) -> MagmaGpuResult<usize> {
         let mut space = [MaybeUninit::<u8>::uninit(); cmsg_space!(ScmRights(MAX_IDENTIFIERS))];
         let mut cmsg_buffer = SendAncillaryBuffer::new(&mut space);

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/tube.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/tube.rs
@@ -28,7 +28,7 @@ impl Tube {
     pub fn send(
         &self,
         _opaque_data: &[u8],
-        _descriptors: &[OwnedDescriptor],
+        _descriptors: Vec<OwnedDescriptor>,
     ) -> MagmaGpuResult<usize> {
         Err(Error::Unsupported)
     }

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/tube.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/tube.rs
@@ -28,7 +28,7 @@ impl Tube {
     pub fn send(
         &self,
         _opaque_data: &[u8],
-        _descriptors: &[OwnedDescriptor],
+        _descriptors: Vec<OwnedDescriptor>,
     ) -> MagmaGpuResult<usize> {
         Err(Error::Unsupported)
     }


### PR DESCRIPTION
Tube::send borrows the descriptors, which is fine where sending duplicates them, as SCM_RIGHTS does. A Mach port right is not duplicated: a receive right is unique and moves to the peer, so the sender is left holding a descriptor for a right it no longer has, and dropping that releases a name it does not own.

Take the descriptors by value, so what a send consumes is in the type. Nothing changes for the socket backends, whose callers dropped them right after the send in any case.