### PR TITLE
magma-gpu-rs: sort the create_event_pair import

### DIFF
--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/virtgpu_kumquat/virtgpu_kumquat_impl.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/virtgpu_kumquat/virtgpu_kumquat_impl.rs
@@ -8,8 +8,8 @@ use std::slice::from_raw_parts_mut;
 
 use crate::protocols::ipc::KumquatStream;
 use crate::protocols::kumquat_gpu_protocol::*;
-use crate::util::Error;
 use crate::util::create_event_pair;
+use crate::util::Error;
 use crate::util::EventWaiter;
 use crate::util::Handle;
 use crate::util::IntoRawDescriptor;


### PR DESCRIPTION
rustfmt orders crate::util::create_event_pair ahead of crate::util::Error, and the event pair commit left it behind. Ordering only.