### PR TITLE
magma-gpu-rs: hand the descriptor to WritePipe::new

### DIFF
--- a/kumquat/server/src/main.rs
+++ b/kumquat/server/src/main.rs
@@ -7,7 +7,9 @@ mod kumquat_gpu;
 
 use clap::Parser;
 use kumquat::KumquatBuilder;
+use magma_gpu::util::FromRawDescriptor;
 use magma_gpu::util::IntoRawDescriptor;
+use magma_gpu::util::OwnedDescriptor;
 use magma_gpu::util::WritePipe;
 
 use crate::kumquat_gpu::KumquatGpuResult;
@@ -43,7 +45,11 @@ fn main() -> KumquatGpuResult<()> {
         .build()?;
 
     if args.pipe_descriptor != 0 {
-        let write_pipe = WritePipe::new(args.pipe_descriptor.into_raw_descriptor());
+        // SAFETY: the caller passed a descriptor it opened and handed over.
+        let descriptor = unsafe {
+            OwnedDescriptor::from_raw_descriptor(args.pipe_descriptor.into_raw_descriptor())
+        };
+        let write_pipe = WritePipe::new(descriptor);
         write_pipe.write(&1u64.to_le_bytes())?;
     }
 

--- a/src/cross_domain/worker.rs
+++ b/src/cross_domain/worker.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use log::error;
 use magma_gpu::util::AsBorrowedDescriptor;
-use magma_gpu::util::AsRawDescriptor;
 use magma_gpu::util::DescriptorType;
 use magma_gpu::util::Error as MagmaGpuError;
 use magma_gpu::util::EventWaiter;
@@ -261,8 +260,7 @@ impl CrossDomainWorker {
                     DescriptorType::WritePipe => {
                         *identifier_type = CROSS_DOMAIN_ID_TYPE_WRITE_PIPE;
                         *identifier_size = 0;
-                        let write_pipe = WritePipe::new(file.as_raw_descriptor());
-                        std::mem::forget(file); // WritePipe now owns the descriptor
+                        let write_pipe = WritePipe::new(file);
                         *identifier = add_item(
                             &self.item_state,
                             CrossDomainItem::WaylandWritePipe(write_pipe),

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/pipe.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/linux/pipe.rs
@@ -9,7 +9,6 @@ use rustix::pipe::pipe;
 
 use crate::util::AsBorrowedDescriptor;
 use crate::util::AsRawDescriptor;
-use crate::util::FromRawDescriptor;
 use crate::util::OwnedDescriptor;
 use crate::util::RawDescriptor;
 use crate::util::Result;
@@ -48,11 +47,8 @@ impl AsBorrowedDescriptor for ReadPipe {
 }
 
 impl WritePipe {
-    pub fn new(descriptor: RawDescriptor) -> WritePipe {
-        // SAFETY: Safe because we know the underlying OS descriptor is valid and
-        // owned by us.
-        let owned = unsafe { OwnedDescriptor::from_raw_descriptor(descriptor) };
-        WritePipe { descriptor: owned }
+    pub fn new(descriptor: OwnedDescriptor) -> WritePipe {
+        WritePipe { descriptor }
     }
 
     pub fn write(&self, data: &[u8]) -> Result<usize> {

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/pipe.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/stub/pipe.rs
@@ -28,7 +28,7 @@ impl AsBorrowedDescriptor for ReadPipe {
 }
 
 impl WritePipe {
-    pub fn new(_descriptor: RawDescriptor) -> WritePipe {
+    pub fn new(_descriptor: OwnedDescriptor) -> WritePipe {
         unimplemented!()
     }
 

--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/pipe.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/util/sys/windows/pipe.rs
@@ -28,7 +28,7 @@ impl AsBorrowedDescriptor for ReadPipe {
 }
 
 impl WritePipe {
-    pub fn new(_descriptor: RawDescriptor) -> WritePipe {
+    pub fn new(_descriptor: OwnedDescriptor) -> WritePipe {
         unimplemented!()
     }
 


### PR DESCRIPTION
WritePipe::new took a raw descriptor and made an owned one out of it, so the caller had to give up its own by hand. Nothing in the type said so, and a caller that forgot left two owners of one descriptor.

Take the OwnedDescriptor, and ownership moves where it is meant to. cross_domain passes the descriptor it holds, and kumquat makes an owned one out of the raw integer it was handed.