### PR TITLE
kumquat: back host visible memory with shared memory on Apple

### DIFF
--- a/kumquat/server/src/kumquat_gpu/mod.rs
+++ b/kumquat/server/src/kumquat_gpu/mod.rs
@@ -127,6 +127,9 @@ impl KumquatGpu {
 
         let rutabaga = RutabagaBuilder::new(capset_mask, fence_handler)
             .set_use_external_blob(true)
+            // Metal cannot export device memory, so host visible memory is
+            // shared memory the host imports as a host pointer instead.
+            .set_use_system_blob(cfg!(target_vendor = "apple"))
             .set_use_egl(true)
             .set_wsi(RutabagaWsi::Surfaceless)
             .set_renderer_features(renderer_features_opt)


### PR DESCRIPTION
vkMapMemory asks the host to export the memory as a blob, and with external blobs alone that is an export of the VkDeviceMemory, which Metal cannot do: the host stops at "ExternalBlob feature is not supported with external memory metal" and the guest waits forever for a reply.

With system blobs the host backs host visible memory with shared memory and imports it as a host pointer, which MoltenVK supports, and the guest is handed the shared memory descriptor it already knows how to map.