### PR TITLE
magma-gpu-rs: bump buffer size

### DIFF
--- a/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/protocols/ipc/kumquat_stream.rs
+++ b/third_party/mesa3d/src/virtio/magma-gpu-rs/lib/protocols/ipc/kumquat_stream.rs
@@ -19,7 +19,7 @@ use zerocopy::IntoBytes;
 
 use crate::protocols::kumquat_gpu_protocol::*;
 
-const MAX_COMMAND_SIZE: usize = 4096;
+const MAX_COMMAND_SIZE: usize = 65536;
 
 pub struct KumquatStream {
     stream: Tube,


### PR DESCRIPTION
Datagrams/packets up to 64 KB are guaranteed to transfer atomically.  Fixes failures for stream size being small.