### PR TITLE
rutabaga_gfx: Add option to bypass gbm and virglrenderer pkg-config probes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,11 +89,13 @@ fn main() -> PkgConfigResult<()> {
     }
 
     if env::var("CARGO_FEATURE_VIRGL_RENDERER").is_ok() {
-        virglrenderer()?;
+        if env::var("CARGO_FEATURE_VIRGL_RENDERER_STUB").is_err() {
+            virglrenderer()?;
+        }
         use_fence_passing_option1 = false;
     }
 
-    if env::var("CARGO_FEATURE_GBM").is_ok() {
+    if env::var("CARGO_FEATURE_GBM").is_ok() && env::var("CARGO_FEATURE_GBM_STUB").is_err() {
         gbm()?;
     }
 


### PR DESCRIPTION
```
Like the existing GFXSTREAM_STUB, skip the gbm and virglrenderer
pkg-config probes when CARGO_FEATURE_GBM_STUB or
CARGO_FEATURE_VIRGL_RENDERER_STUB is set.
```
This is needed for Cuttlefish, which provides these dependencies through its Bazel build rather than through pkg-config: https://github.com/google/android-cuttlefish/blob/6d0d2284d06c86c0bc578d595b7fbef2f6d75388/base/cvd/build_external/crosvm/crosvm.MODULE.bazel#L64

One detail worth noting is that enabling the `virgl_renderer` feature disables `use_fence_passing_option1`. Not sure if that would be an issue for Cuttlefish.

cc @gurchetansingh @jmacnak @valpackett @zzyiwei 